### PR TITLE
fix(hue): echte Subnetz-Prüfung statt "irgendein WLAN" vor Bridge-Zugriff

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -52,8 +52,8 @@ android {
         applicationId = "com.github.f1rlefanz.cf_alarmfortimeoffice"
         minSdk = 26
         targetSdk = 37
-        versionCode = 63
-        versionName = "1.15.0"
+        versionCode = 64
+        versionName = "1.15.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/hue/connection/HueBridgeConnectionManager.kt
+++ b/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/hue/connection/HueBridgeConnectionManager.kt
@@ -75,6 +75,7 @@ class HueBridgeConnectionManager private constructor(
                 INSTANCE ?: HueBridgeConnectionManager(
                     context.applicationContext,
                     com.github.f1rlefanz.cf_alarmfortimeoffice.util.NetworkStateMonitor(context.applicationContext),
+                    // Context enables the bridge-ID pinning audit layer in HueTrustManager
                     HueApiClient(context.applicationContext)
                 ).also { INSTANCE = it }
             }

--- a/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/hue/connection/HueBridgeConnectionManager.kt
+++ b/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/hue/connection/HueBridgeConnectionManager.kt
@@ -62,18 +62,34 @@ interface HueBridgeConnectionManagerEntryPoint {
  * MEMORY LEAK FIX: Uses WeakReference to Context to prevent memory leaks
  */
 class HueBridgeConnectionManager private constructor(
-    context: Context
+    context: Context,
+    private val networkMonitor: com.github.f1rlefanz.cf_alarmfortimeoffice.util.NetworkStateMonitor,
+    private val apiClient: HueApiClient
 ) {
     companion object {
         @Volatile
         private var INSTANCE: HueBridgeConnectionManager? = null
-        
+
         fun getInstance(context: Context): HueBridgeConnectionManager {
             return INSTANCE ?: synchronized(this) {
-                INSTANCE ?: HueBridgeConnectionManager(context.applicationContext).also { INSTANCE = it }
+                INSTANCE ?: HueBridgeConnectionManager(
+                    context.applicationContext,
+                    com.github.f1rlefanz.cf_alarmfortimeoffice.util.NetworkStateMonitor(context.applicationContext),
+                    HueApiClient(context.applicationContext)
+                ).also { INSTANCE = it }
             }
         }
-        
+
+        /**
+         * Visible for testing: lets a unit test construct the manager with fakes for
+         * networkMonitor/apiClient without touching the production getInstance() singleton.
+         */
+        internal fun createForTesting(
+            context: Context,
+            networkMonitor: com.github.f1rlefanz.cf_alarmfortimeoffice.util.NetworkStateMonitor,
+            apiClient: HueApiClient
+        ): HueBridgeConnectionManager = HueBridgeConnectionManager(context, networkMonitor, apiClient)
+
         // Configuration constants
         // CONSOLIDATION: moved off the standalone "hue_bridge_connection" SharedPreferences
         // file and into the existing Hilt @HueDataStore (see HueBridgeConnectionManagerEntryPoint).
@@ -93,8 +109,6 @@ class HueBridgeConnectionManager private constructor(
     
     // Use WeakReference to prevent memory leaks
     private val contextRef = java.lang.ref.WeakReference(context.applicationContext)
-    // Context enables the bridge-ID pinning audit layer in HueTrustManager
-    private val apiClient = HueApiClient(context)
 
     // PHASE 2: Smart Scheduler integration
     private val smartScheduler by lazy {
@@ -216,9 +230,22 @@ class HueBridgeConnectionManager private constructor(
         
         when (currentState) {
             is ConnectionState.CONNECTED -> {
+                // Synchronous pre-flight: skip the real HTTP attempt entirely when we're
+                // demonstrably not on the bridge's local network (off Wi-Fi, or on a
+                // different Wi-Fi/subnet - e.g. public/work Wi-Fi, mobile hotspot). Deliberately
+                // NOT downgrading currentConnectionState to ERROR: this is a transient
+                // "wrong network right now" condition, not a bridge/credential failure - the
+                // 30-min cache should survive the trip so no needless reconnect/health-check
+                // cycle fires the moment Wi-Fi is back, and the UI doesn't flash a misleading
+                // persistent error banner while just out of range.
+                if (!isBridgeReachableNow(currentState.bridgeIp)) {
+                    Logger.w(LogTags.HUE_BRIDGE, "⚠️ BRIDGE-MANAGER: Cached bridge ${currentState.bridgeIp} not reachable from current network, skipping live connection attempt")
+                    throw IllegalStateException("Bridge unreachable: not on the bridge's local network (${currentState.bridgeIp})")
+                }
+
                 // OPTIMIZATION: Extended cache validity - trust connection longer
                 val isRecent = (System.currentTimeMillis() - currentState.lastValidated) < CONNECTION_CACHE_VALIDITY.inWholeMilliseconds
-                
+
                 if (isRecent) {
                     Logger.d(LogTags.HUE_BRIDGE, "✅ BRIDGE-MANAGER: Using cached valid connection (${CONNECTION_CACHE_VALIDITY.inWholeMinutes}min cache)")
                     return@withContext Pair(currentState.bridgeIp, currentState.username)
@@ -500,19 +527,26 @@ class HueBridgeConnectionManager private constructor(
     }
     
     /**
+     * INTERNAL: Cheap, synchronous pre-flight - is [bridgeIp] reachable from the CURRENT
+     * network? Only meaningful for local/private bridge IPs; a non-local IP (shouldn't
+     * happen for Hue, but defensive) is always considered reachable since the subnet check
+     * doesn't apply to it.
+     */
+    private fun isBridgeReachableNow(bridgeIp: String): Boolean {
+        val isPrivateIp = bridgeIp.startsWith("192.168.") || bridgeIp.startsWith("10.") || bridgeIp.startsWith("172.")
+        if (!isPrivateIp) return true
+        return networkMonitor.isReachableSubnet(bridgeIp)
+    }
+
+    /**
      * INTERNAL: Validate connection credentials against bridge
      */
     private suspend fun validateConnectionCredentials(bridgeIp: String, username: String): Boolean {
-        val context = contextRef.get()
-        if (context != null) {
-            val networkMonitor = com.github.f1rlefanz.cf_alarmfortimeoffice.util.NetworkStateMonitor(context)
-            // Skip connection attempt if we're not on Wi-Fi/Ethernet and the IP is a local network IP
-            if (!networkMonitor.isWifiConnected() && (bridgeIp.startsWith("192.168.") || bridgeIp.startsWith("10.") || bridgeIp.startsWith("172."))) {
-                Logger.w(LogTags.HUE_BRIDGE, "⚠️ BRIDGE-MANAGER: Not on Wi-Fi, skipping local bridge connection to $bridgeIp")
-                return false
-            }
+        if (!isBridgeReachableNow(bridgeIp)) {
+            Logger.w(LogTags.HUE_BRIDGE, "⚠️ BRIDGE-MANAGER: $bridgeIp not reachable from current network (off home Wi-Fi or wrong subnet), skipping bridge connection")
+            return false
         }
-        
+
         return try {
             apiClient.getBridgeConfig(bridgeIp, username)
             Logger.d(LogTags.HUE_BRIDGE, "✅ BRIDGE-MANAGER: Connection validation successful")

--- a/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/util/NetworkStateMonitor.kt
+++ b/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/util/NetworkStateMonitor.kt
@@ -9,22 +9,26 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
+import java.net.Inet4Address
+import java.net.InetAddress
 
 /**
  * Network State Monitor für Offline-Support Optimierungen
- * 
+ *
  * PERFORMANCE FEATURES:
  * ✅ Reactive Network State Monitoring mit Flow
  * ✅ Automatische Background-Sync bei Netzwerk-Wiederherstellung
  * ✅ Intelligente Offline-Erkennung
  * ✅ Battery-efficient monitoring
- * 
+ *
  * Note: minSdk is 26, so all modern network APIs are available
  */
 @Suppress("unused") // Used for future offline-support features
-class NetworkStateMonitor(context: Context) {
-    
-    private val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+class NetworkStateMonitor(private val connectivityManager: ConnectivityManager) {
+
+    constructor(context: Context) : this(
+        context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+    )
     
     /**
      * Flow that emits true when network is available, false when offline
@@ -91,8 +95,79 @@ class NetworkStateMonitor(context: Context) {
     fun isWifiConnected(): Boolean {
         val activeNetwork = connectivityManager.activeNetwork ?: return false
         val networkCapabilities = connectivityManager.getNetworkCapabilities(activeNetwork) ?: return false
-        
-        return networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) || 
+
+        return networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) ||
                networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)
+    }
+
+    /**
+     * Checks whether [targetIp] (a literal IPv4 address, e.g. a local Hue Bridge) is reachable
+     * from the phone's CURRENT network - i.e. whether the active network's own IPv4 address
+     * shares a subnet with [targetIp], per its advertised prefix length.
+     *
+     * Unlike [isWifiConnected], this is not fooled by "connected to *some* Wi-Fi" (public
+     * Wi-Fi, mobile hotspot, guest network) - it only returns true if the phone's IP is
+     * actually in the same subnet as the target, regardless of what private range the home
+     * network uses.
+     *
+     * Returns false (never throws) when: no active network, no LinkProperties, no IPv4
+     * LinkAddress on the active network (e.g. cellular, IPv6-only), or [targetIp] is not a
+     * valid dotted-quad IPv4 literal.
+     */
+    fun isReachableSubnet(targetIp: String): Boolean {
+        val targetAddress = parseIpv4Literal(targetIp) ?: run {
+            Logger.w(LogTags.NETWORK, "⚠️ NETWORK: Cannot parse target IP '$targetIp' as IPv4 literal")
+            return false
+        }
+        val activeNetwork = connectivityManager.activeNetwork ?: run {
+            Logger.d(LogTags.NETWORK, "No active network - subnet check for $targetIp fails")
+            return false
+        }
+        val linkProperties = connectivityManager.getLinkProperties(activeNetwork) ?: return false
+
+        val matched = linkProperties.linkAddresses.any { linkAddress ->
+            val deviceAddress = linkAddress.address
+            deviceAddress is Inet4Address &&
+                isSameSubnet(deviceAddress.address, targetAddress.address, linkAddress.prefixLength)
+        }
+        if (!matched) {
+            Logger.d(LogTags.NETWORK, "🌐 NETWORK: $targetIp not reachable - no matching local IPv4 subnet")
+        }
+        return matched
+    }
+
+    /** Parses a literal IPv4 dotted-quad WITHOUT any DNS/network I/O (no getByName side effects). */
+    private fun parseIpv4Literal(ip: String): InetAddress? {
+        val parts = ip.split(".")
+        if (parts.size != 4) return null
+        val bytes = ByteArray(4)
+        for (i in 0..3) {
+            val octet = parts[i].toIntOrNull() ?: return null
+            if (octet !in 0..255) return null
+            bytes[i] = octet.toByte()
+        }
+        return try {
+            InetAddress.getByAddress(bytes)
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    companion object {
+        /** CIDR containment: do [deviceBytes] and [targetBytes] share the same [prefixLength]-bit prefix? */
+        internal fun isSameSubnet(deviceBytes: ByteArray, targetBytes: ByteArray, prefixLength: Int): Boolean {
+            if (deviceBytes.size != targetBytes.size) return false // family mismatch (v4 vs v6)
+            if (prefixLength <= 0) return true
+            val fullBytes = prefixLength / 8
+            val remainingBits = prefixLength % 8
+            for (i in 0 until fullBytes.coerceAtMost(deviceBytes.size)) {
+                if (deviceBytes[i] != targetBytes[i]) return false
+            }
+            if (remainingBits > 0 && fullBytes < deviceBytes.size) {
+                val mask = (0xFF shl (8 - remainingBits)) and 0xFF
+                if ((deviceBytes[fullBytes].toInt() and mask) != (targetBytes[fullBytes].toInt() and mask)) return false
+            }
+            return true
+        }
     }
 }

--- a/app/src/test/java/com/github/f1rlefanz/cf_alarmfortimeoffice/hue/connection/HueBridgeConnectionManagerTest.kt
+++ b/app/src/test/java/com/github/f1rlefanz/cf_alarmfortimeoffice/hue/connection/HueBridgeConnectionManagerTest.kt
@@ -1,0 +1,92 @@
+package com.github.f1rlefanz.cf_alarmfortimeoffice.hue.connection
+
+import android.content.Context
+import com.github.f1rlefanz.cf_alarmfortimeoffice.hue.api.HueApiClient
+import com.github.f1rlefanz.cf_alarmfortimeoffice.util.NetworkStateMonitor
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+/**
+ * Unit tests for the "off-network pre-flight" guard in [HueBridgeConnectionManager.getValidatedConnection].
+ *
+ * Background: real debug logs (2026-07-20/22) showed the app attempting a real HTTPS request
+ * to the Hue Bridge - and waiting out a 10s [java.net.SocketTimeoutException] - even though the
+ * phone was demonstrably not on the bridge's network. That happened because the cached
+ * `ConnectionState.CONNECTED` fast path in `getValidatedConnection()` returned the bridge
+ * IP/credentials with no reachability check at all. These tests lock in the fix: when
+ * [NetworkStateMonitor.isReachableSubnet] says the bridge isn't reachable, the manager must
+ * fail fast WITHOUT ever calling the real API client, and must not downgrade the cached
+ * connection state (a transient "wrong network" isn't a bridge/credential failure).
+ */
+class HueBridgeConnectionManagerTest {
+
+    private val bridgeIp = "192.168.178.24"
+    private val username = "test-user"
+
+    private fun buildManager(
+        isReachable: Boolean,
+    ): Triple<HueBridgeConnectionManager, NetworkStateMonitor, HueApiClient> {
+        val context = mock<Context>()
+        whenever(context.applicationContext).thenReturn(context)
+
+        val networkMonitor = mock<NetworkStateMonitor>()
+        whenever(networkMonitor.isReachableSubnet(any())).thenReturn(isReachable)
+
+        val apiClient = mock<HueApiClient>()
+
+        val manager = HueBridgeConnectionManager.createForTesting(context, networkMonitor, apiClient)
+        seedConnectedState(manager)
+
+        return Triple(manager, networkMonitor, apiClient)
+    }
+
+    /** Seeds the private `currentConnectionState` field directly - there is no public setter,
+     * and driving it through [HueBridgeConnectionManager.setConnection] would require a real
+     * Hilt-provided DataStore, which isn't available in a plain unit test. */
+    private fun seedConnectedState(manager: HueBridgeConnectionManager) {
+        val connectedState = HueBridgeConnectionManager.ConnectionState.CONNECTED(bridgeIp, username)
+        val field = HueBridgeConnectionManager::class.java.getDeclaredField("currentConnectionState")
+        field.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        val ref = field.get(manager) as java.util.concurrent.atomic.AtomicReference<HueBridgeConnectionManager.ConnectionState>
+        ref.set(connectedState)
+    }
+
+    @Test
+    fun `off-subnet cached connection throws without ever calling the real API client`() = runBlocking {
+        val (manager, _, apiClient) = buildManager(isReachable = false)
+
+        assertThrows(IllegalStateException::class.java) {
+            runBlocking { manager.getValidatedConnection() }
+        }
+
+        verify(apiClient, never()).getBridgeConfig(any(), any())
+    }
+
+    @Test
+    fun `off-subnet cached connection does not downgrade connection state to ERROR`() = runBlocking {
+        val (manager, _, _) = buildManager(isReachable = false)
+
+        runCatching { manager.getValidatedConnection() }
+
+        assertTrue(manager.connectionStatus.value is HueBridgeConnectionManager.ConnectionState.CONNECTED)
+    }
+
+    @Test
+    fun `on-subnet cached connection returns cached credentials without calling the API`() = runBlocking {
+        val (manager, _, apiClient) = buildManager(isReachable = true)
+
+        val (returnedIp, returnedUser) = manager.getValidatedConnection()
+
+        assertTrue(returnedIp == bridgeIp && returnedUser == username)
+        // Fresh cache (just seeded) - still within CONNECTION_CACHE_VALIDITY, so no API call needed.
+        verify(apiClient, never()).getBridgeConfig(any(), any())
+    }
+}

--- a/app/src/test/java/com/github/f1rlefanz/cf_alarmfortimeoffice/hue/connection/HueBridgeConnectionManagerTest.kt
+++ b/app/src/test/java/com/github/f1rlefanz/cf_alarmfortimeoffice/hue/connection/HueBridgeConnectionManagerTest.kt
@@ -47,16 +47,22 @@ class HueBridgeConnectionManagerTest {
         return Triple(manager, networkMonitor, apiClient)
     }
 
-    /** Seeds the private `currentConnectionState` field directly - there is no public setter,
-     * and driving it through [HueBridgeConnectionManager.setConnection] would require a real
-     * Hilt-provided DataStore, which isn't available in a plain unit test. */
+    /** Seeds a CONNECTED state via the private `updateConnectionState` method - there is no
+     * public setter, and driving it through [HueBridgeConnectionManager.setConnection] would
+     * require a real Hilt-provided DataStore, which isn't available in a plain unit test.
+     * Goes through `updateConnectionState` rather than poking the `currentConnectionState`
+     * field directly, since that method is also the only thing that keeps the separate
+     * `_connectionStatus` StateFlow (what [HueBridgeConnectionManager.connectionStatus] reads)
+     * in sync - setting just the field would leave `connectionStatus.value` stuck at its
+     * initial DISCONNECTED. */
     private fun seedConnectedState(manager: HueBridgeConnectionManager) {
         val connectedState = HueBridgeConnectionManager.ConnectionState.CONNECTED(bridgeIp, username)
-        val field = HueBridgeConnectionManager::class.java.getDeclaredField("currentConnectionState")
-        field.isAccessible = true
-        @Suppress("UNCHECKED_CAST")
-        val ref = field.get(manager) as java.util.concurrent.atomic.AtomicReference<HueBridgeConnectionManager.ConnectionState>
-        ref.set(connectedState)
+        val method = HueBridgeConnectionManager::class.java.getDeclaredMethod(
+            "updateConnectionState",
+            HueBridgeConnectionManager.ConnectionState::class.java,
+        )
+        method.isAccessible = true
+        method.invoke(manager, connectedState)
     }
 
     // NOTE: block bodies (not `= runBlocking { ... }` expression bodies) are deliberate here -

--- a/app/src/test/java/com/github/f1rlefanz/cf_alarmfortimeoffice/hue/connection/HueBridgeConnectionManagerTest.kt
+++ b/app/src/test/java/com/github/f1rlefanz/cf_alarmfortimeoffice/hue/connection/HueBridgeConnectionManagerTest.kt
@@ -59,34 +59,45 @@ class HueBridgeConnectionManagerTest {
         ref.set(connectedState)
     }
 
-    @Test
-    fun `off-subnet cached connection throws without ever calling the real API client`() = runBlocking {
-        val (manager, _, apiClient) = buildManager(isReachable = false)
+    // NOTE: block bodies (not `= runBlocking { ... }` expression bodies) are deliberate here -
+    // JUnit4 requires @Test methods to return void, and an expression body whose last statement
+    // is a `verify(mock).suspendFun(...)` call would otherwise infer a non-Unit return type
+    // (the suspend function's return type), which JUnit4 rejects with InvalidTestClassError.
 
-        assertThrows(IllegalStateException::class.java) {
-            runBlocking { manager.getValidatedConnection() }
+    @Test
+    fun `off-subnet cached connection throws without ever calling the real API client`() {
+        runBlocking {
+            val (manager, _, apiClient) = buildManager(isReachable = false)
+
+            assertThrows(IllegalStateException::class.java) {
+                runBlocking { manager.getValidatedConnection() }
+            }
+
+            verify(apiClient, never()).getBridgeConfig(any(), any())
         }
-
-        verify(apiClient, never()).getBridgeConfig(any(), any())
     }
 
     @Test
-    fun `off-subnet cached connection does not downgrade connection state to ERROR`() = runBlocking {
-        val (manager, _, _) = buildManager(isReachable = false)
+    fun `off-subnet cached connection does not downgrade connection state to ERROR`() {
+        runBlocking {
+            val (manager, _, _) = buildManager(isReachable = false)
 
-        runCatching { manager.getValidatedConnection() }
+            runCatching { manager.getValidatedConnection() }
 
-        assertTrue(manager.connectionStatus.value is HueBridgeConnectionManager.ConnectionState.CONNECTED)
+            assertTrue(manager.connectionStatus.value is HueBridgeConnectionManager.ConnectionState.CONNECTED)
+        }
     }
 
     @Test
-    fun `on-subnet cached connection returns cached credentials without calling the API`() = runBlocking {
-        val (manager, _, apiClient) = buildManager(isReachable = true)
+    fun `on-subnet cached connection returns cached credentials without calling the API`() {
+        runBlocking {
+            val (manager, _, apiClient) = buildManager(isReachable = true)
 
-        val (returnedIp, returnedUser) = manager.getValidatedConnection()
+            val (returnedIp, returnedUser) = manager.getValidatedConnection()
 
-        assertTrue(returnedIp == bridgeIp && returnedUser == username)
-        // Fresh cache (just seeded) - still within CONNECTION_CACHE_VALIDITY, so no API call needed.
-        verify(apiClient, never()).getBridgeConfig(any(), any())
+            assertTrue(returnedIp == bridgeIp && returnedUser == username)
+            // Fresh cache (just seeded) - still within CONNECTION_CACHE_VALIDITY, so no API call needed.
+            verify(apiClient, never()).getBridgeConfig(any(), any())
+        }
     }
 }

--- a/app/src/test/java/com/github/f1rlefanz/cf_alarmfortimeoffice/util/NetworkStateMonitorTest.kt
+++ b/app/src/test/java/com/github/f1rlefanz/cf_alarmfortimeoffice/util/NetworkStateMonitorTest.kt
@@ -1,0 +1,163 @@
+package com.github.f1rlefanz.cf_alarmfortimeoffice.util
+
+import android.net.ConnectivityManager
+import android.net.LinkAddress
+import android.net.LinkProperties
+import android.net.Network
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.net.Inet4Address
+import java.net.Inet6Address
+import java.net.InetAddress
+
+/**
+ * Unit tests for [NetworkStateMonitor.isReachableSubnet] — the real CIDR-based "am I on the
+ * same subnet as this local IP" check that replaced the old transport-type-only
+ * ("bin ich in irgendeinem WLAN") heuristic.
+ *
+ * The IPs used in the "wrong subnet" cases below are taken verbatim from real
+ * CF-Alarm-for-TimeOffice debug logs (2026-07-20/22) where the Hue Bridge
+ * (192.168.178.24) timed out because the phone was on some other network.
+ */
+class NetworkStateMonitorTest {
+
+    private fun ipv4(ip: String): Inet4Address = InetAddress.getByName(ip) as Inet4Address
+
+    private fun linkAddress(ip: String, prefixLength: Int): LinkAddress {
+        val la = mock<LinkAddress>()
+        whenever(la.address).thenReturn(ipv4(ip))
+        whenever(la.prefixLength).thenReturn(prefixLength)
+        return la
+    }
+
+    private fun monitorWithLinkAddresses(vararg addresses: LinkAddress): NetworkStateMonitor {
+        val connectivityManager = mock<ConnectivityManager>()
+        val network = mock<Network>()
+        val linkProperties = mock<LinkProperties>()
+        whenever(connectivityManager.activeNetwork).thenReturn(network)
+        whenever(connectivityManager.getLinkProperties(network)).thenReturn(linkProperties)
+        whenever(linkProperties.linkAddresses).thenReturn(addresses.toList())
+        return NetworkStateMonitor(connectivityManager)
+    }
+
+    private fun monitorWithNoActiveNetwork(): NetworkStateMonitor {
+        val connectivityManager = mock<ConnectivityManager>()
+        whenever(connectivityManager.activeNetwork).thenReturn(null)
+        return NetworkStateMonitor(connectivityManager)
+    }
+
+    private fun monitorWithNoLinkProperties(): NetworkStateMonitor {
+        val connectivityManager = mock<ConnectivityManager>()
+        val network = mock<Network>()
+        whenever(connectivityManager.activeNetwork).thenReturn(network)
+        whenever(connectivityManager.getLinkProperties(network)).thenReturn(null)
+        return NetworkStateMonitor(connectivityManager)
+    }
+
+    @Test
+    fun `no active network - not reachable`() {
+        assertFalse(monitorWithNoActiveNetwork().isReachableSubnet("192.168.178.24"))
+    }
+
+    @Test
+    fun `no link properties - not reachable`() {
+        assertFalse(monitorWithNoLinkProperties().isReachableSubnet("192.168.178.24"))
+    }
+
+    @Test
+    fun `same home subnet - reachable`() {
+        val monitor = monitorWithLinkAddresses(linkAddress("192.168.178.50", 24))
+        assertTrue(monitor.isReachableSubnet("192.168.178.24"))
+    }
+
+    @Test
+    fun `wrong private subnet - not reachable (log case 2026-07-22 08-55, 192-168-44-84)`() {
+        val monitor = monitorWithLinkAddresses(linkAddress("192.168.44.84", 24))
+        assertFalse(monitor.isReachableSubnet("192.168.178.24"))
+    }
+
+    @Test
+    fun `wrong private subnet - not reachable (log case 2026-07-20 12-45, 10-0-9-10)`() {
+        val monitor = monitorWithLinkAddresses(linkAddress("10.0.9.10", 24))
+        assertFalse(monitor.isReachableSubnet("192.168.178.24"))
+    }
+
+    @Test
+    fun `CGNAT mobile-data address - not reachable (log case 2026-07-22 08-43, 100-72-201-243)`() {
+        val monitor = monitorWithLinkAddresses(linkAddress("100.72.201.243", 16))
+        assertFalse(monitor.isReachableSubnet("192.168.178.24"))
+    }
+
+    @Test
+    fun `IPv6-only link address - not reachable`() {
+        val la = mock<LinkAddress>()
+        val v6 = mock<Inet6Address>()
+        whenever(la.address).thenReturn(v6)
+        val monitor = monitorWithLinkAddresses(la)
+        assertFalse(monitor.isReachableSubnet("192.168.178.24"))
+    }
+
+    @Test
+    fun `multiple link addresses - matches when any one is on the same subnet`() {
+        val monitor = monitorWithLinkAddresses(
+            linkAddress("10.0.9.10", 24),
+            linkAddress("192.168.178.50", 24),
+        )
+        assertTrue(monitor.isReachableSubnet("192.168.178.24"))
+    }
+
+    @Test
+    fun `malformed target ip does not throw and is not reachable`() {
+        val monitor = monitorWithLinkAddresses(linkAddress("192.168.178.50", 24))
+        assertFalse(monitor.isReachableSubnet(""))
+        assertFalse(monitor.isReachableSubnet("not.an.ip"))
+        assertFalse(monitor.isReachableSubnet("999.1.1.1"))
+        assertFalse(monitor.isReachableSubnet("192.168.1"))
+    }
+
+    // --- isSameSubnet (pure CIDR math, exercised directly across prefix boundaries) -------
+
+    private fun bytes(ip: String) = ipv4(ip).address
+
+    @Test
+    fun `isSameSubnet prefix 0 always matches`() {
+        assertTrue(NetworkStateMonitor.isSameSubnet(bytes("1.2.3.4"), bytes("250.250.250.250"), 0))
+    }
+
+    @Test
+    fun `isSameSubnet prefix 8 byte-aligned`() {
+        assertTrue(NetworkStateMonitor.isSameSubnet(bytes("10.1.2.3"), bytes("10.99.99.99"), 8))
+        assertFalse(NetworkStateMonitor.isSameSubnet(bytes("10.1.2.3"), bytes("11.1.2.3"), 8))
+    }
+
+    @Test
+    fun `isSameSubnet prefix 24 byte-aligned`() {
+        assertTrue(NetworkStateMonitor.isSameSubnet(bytes("192.168.178.50"), bytes("192.168.178.24"), 24))
+        assertFalse(NetworkStateMonitor.isSameSubnet(bytes("192.168.44.84"), bytes("192.168.178.24"), 24))
+    }
+
+    @Test
+    fun `isSameSubnet prefix 25 non byte-aligned`() {
+        // 192.168.1.100 and 192.168.1.120 are both in 192.168.1.0/25 (0-127)
+        assertTrue(NetworkStateMonitor.isSameSubnet(bytes("192.168.1.100"), bytes("192.168.1.120"), 25))
+        // 192.168.1.100 (/25 -> 0-127) vs 192.168.1.200 (128-255) - different half
+        assertFalse(NetworkStateMonitor.isSameSubnet(bytes("192.168.1.100"), bytes("192.168.1.200"), 25))
+    }
+
+    @Test
+    fun `isSameSubnet prefix 30 non byte-aligned`() {
+        // 192.168.1.1 and 192.168.1.2 are both in 192.168.1.0/30 (0-3)
+        assertTrue(NetworkStateMonitor.isSameSubnet(bytes("192.168.1.1"), bytes("192.168.1.2"), 30))
+        // 192.168.1.1 (/30 -> 0-3) vs 192.168.1.5 (4-7) - different block
+        assertFalse(NetworkStateMonitor.isSameSubnet(bytes("192.168.1.1"), bytes("192.168.1.5"), 30))
+    }
+
+    @Test
+    fun `isSameSubnet prefix 32 requires exact match`() {
+        assertTrue(NetworkStateMonitor.isSameSubnet(bytes("192.168.178.24"), bytes("192.168.178.24"), 32))
+        assertFalse(NetworkStateMonitor.isSameSubnet(bytes("192.168.178.24"), bytes("192.168.178.25"), 32))
+    }
+}

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,0 +1,44 @@
+# Handoff — CF-Alarm for TimeOffice
+
+**Lebendes Dokument.** Erledigtes wird gelöscht, nicht abgehakt oder durchgestrichen — was hier steht, ist offen.
+Die Historie steht im Git-Log, nicht hier.
+
+**Stand:** 22.07.2026 · `main` = **v1.15.1 / versionCode 64** · alles gemerged und gepusht.
+
+> **Ungeprüft:** der WLAN-Subnetz-Fix (v1.15.1) ist per Unit-Test gegen die realen Log-Fälle
+> (192.168.44.x, 10.0.9.x, CGNAT-Adresse) abgesichert und CI-grün, aber **nicht** am Gerät in
+> einem echten fremden WLAN bestätigt. Alles Übrige aus v1.15.0/v1.15.1 ist bereits am Gerät
+> bzw. im Log verifiziert.
+
+---
+
+## Offen
+
+### 1. WLAN-Subnetz-Fix am Gerät bestätigen ← wichtigster Punkt
+
+Auslöser: drei Debug-Logs (20.–22.07.) zeigten wiederholte 10-Sekunden-Timeouts beim
+Hue-Bridge-Zugriff, obwohl der WLAN-Check aus v1.9.5 schon existierte. Ursache war doppelt:
+der Check prüfte nur „irgendein WLAN", nicht das richtige Subnetz, und griff im
+Alarm-Hot-Path (gecachte Verbindung, 30-Minuten-Cache) gar nicht.
+
+**Test:** Bridge zuhause verbinden (Status-Tab zeigt „Verbunden"), dann Handy in ein fremdes
+WLAN oder auf Mobilfunk umschalten, während die Verbindung noch als „verbunden" gilt (siehe
+30-Minuten-Cache). Zu prüfen:
+1. Kommt im Log sofort `"not reachable from current network"` statt eines
+   `SocketTimeoutException` nach 10s?
+2. Bleibt der Verbindungsstatus im Hue-Tab bei „Verbunden" stehen (kein falscher
+   „Fehler"-Banner), bis man wirklich wieder im Heim-WLAN ist?
+3. Funktioniert die Lichtsteuerung wieder sofort, sobald man zurück im Heim-WLAN ist (kein
+   unnötiger Reconnect-Zyklus)?
+
+### 2. Log-Rauschen bei „Nicht verwendete Apps"-Check
+
+Beim Prüfen der drei Logs aus Punkt 1 aufgefallen, aber bewusst nicht mit angefasst: Wenn man
+den Status-Tab verlässt, während `UnusedAppRestrictionsHelper.isRestricted()` noch läuft,
+wird die dabei entstehende `CancellationException` als `E/CFAlarm.UnusedAppRestrictions:
+Failed to check unused-app-restrictions status` samt zwei
+`LeftCompositionCancellationException`-Stacktraces geloggt. Funktional harmlos (fail-open,
+liefert dann `false`), aber irreführend fürs Log-Lesen. Ursache:
+`UnusedAppRestrictionsHelper.kt:73-78`, `catch (e: Exception)` fängt auch die normale
+Coroutine-Cancellation ab. Fix wäre, `CancellationException` separat durchzureichen statt zu
+loggen.

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -46,7 +46,19 @@
         </div>
 
         <div class="content-card">
-            <h3>🆕 Version 1.15.0 <small>(Aktuell – interne Alpha)</small></h3>
+            <h3>🆕 Version 1.15.1 <small>(Aktuell – interne Alpha)</small></h3>
+            <p><strong>Stand:</strong> Juli 2026</p>
+            <p><em>Der WLAN-Check vor dem Hue-Bridge-Zugriff erkennt jetzt auch ein falsches WLAN.</em></p>
+
+            <h4>🐛 Behoben</h4>
+            <ul>
+                <li><strong>Verbindungsversuch zur Hue-Bridge trotz falschem WLAN:</strong> Der bestehende Schutz (v1.9.5) prüfte nur, ob überhaupt ein WLAN aktiv ist – in einem fremden WLAN (Arbeit, Hotspot, Gäste-Netz) galt das fälschlich als „erreichbar", und die App versuchte trotzdem, die Bridge zu kontaktieren und wartete den vollen 10-Sekunden-Timeout aus. Der Check vergleicht jetzt die tatsächliche Subnetzzugehörigkeit statt nur den Verbindungstyp.</li>
+                <li><strong>Derselbe blinde Fleck bestand auch beim Wecker selbst:</strong> Bei einer bereits zwischengespeicherten Bridge-Verbindung (der Normalfall dank 30-Minuten-Cache) griff der WLAN-Check bisher gar nicht – jetzt wird auch dort vorab geprüft, bevor ein echter Netzwerkzugriff versucht wird.</li>
+            </ul>
+        </div>
+
+        <div class="content-card">
+            <h3>Version 1.15.0</h3>
             <p><strong>Stand:</strong> Juli 2026</p>
             <p><em>Zeitzonen-Fix, ein einheitlicher Herstellerhinweis und ein Aufräumen-Button für Debug-Logs.</em></p>
 


### PR DESCRIPTION
## Summary

Debug-Logs vom 20.–22.07.2026 zeigten wiederkehrende `SocketTimeoutException`-Cluster beim Versuch, die Hue-Bridge (fixe LAN-IP) zu erreichen, obwohl seit v1.9.5 bereits ein WLAN-Guard existiert. Root Cause: zwei Lücken im bestehenden Fix.

- `NetworkStateMonitor.isWifiConnected()` prüfte nur den Transport-Typ ("bin ich in irgendeinem WLAN"), nicht das Subnetz. Ein fremdes WLAN (Arbeit, Hotspot, Gäste-Netz) ließ den Check `true` liefern, obwohl die Bridge unerreichbar war. Aus den Logs extrahierte Client-IPs bei den Timeouts (`100.72.201.243`, `192.168.44.84`, `10.0.9.10`) bestätigen: in keinem Fall war das Handy im Heimnetz der Bridge.
- Der Guard saß nur in `validateConnectionCredentials()`, wurde aber im tatsächlichen Alarm-Hot-Path (`getValidatedConnection()` bei gecachter `CONNECTED`-Verbindung — der Normalfall dank 30-Minuten-Cache) gar nicht aufgerufen: dort ging die IP ungeprüft direkt an `HueLightRepository` für den echten HTTP-Call.

## Changes

- `NetworkStateMonitor`: neue `isReachableSubnet(targetIp)` macht einen echten CIDR-Abgleich zwischen der aktuellen Geräte-IP/Subnetzmaske (`LinkProperties`) und der Bridge-IP — funktioniert für jedes Heimnetz, nicht nur `192.168.178.x`. Konstruktor-Seam (`ConnectivityManager` statt `Context`) für Testbarkeit.
- `HueBridgeConnectionManager`: neuer `isBridgeReachableNow()`-Helper ersetzt den alten String-Präfix/`isWifiConnected()`-Guard in `validateConnectionCredentials()` **und** wird jetzt zusätzlich synchron vor dem gecachten `CONNECTED`-Pfad in `getValidatedConnection()` geprüft — schließt die Hot-Path-Lücke. Bei "falschem Netz gerade" wird der State bewusst **nicht** auf `ERROR` heruntergestuft (kein Verbindungsfehler, nur vorübergehend außerhalb des Heimnetzes).
- Konstruktor-Seam (`networkMonitor`/`apiClient` injizierbar, `createForTesting`) analog zum bestehenden Hilt-EntryPoint-Muster der Klasse.

## Test plan

- [x] Neue Unit-Tests `NetworkStateMonitorTest` (CIDR-Mathematik inkl. der exakten Log-Fälle als Regressionstests) und `HueBridgeConnectionManagerTest` (Guard verhindert echten API-Call, State bleibt `CONNECTED`)
- [ ] `./gradlew testDebugUnitTest` / `lintDebug` / `assembleDebug` über CI (lokal in dieser Sitzung nicht ausführbar — Sandbox-Netzwerkzugriff auf `dl.google.com`/Gradle-Distribution blockiert)
- [ ] Manuell: Bridge verbinden, dann fremdes WLAN/Mobilfunk aktivieren und prüfen, dass sofort "not reachable from current network" geloggt wird statt eines 10s-Timeouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014TGcXPGYdVDYm3RaHiLbS4)_