### PR TITLE
chore(release): v1.15.2 - CancellationException nicht mehr als Fehler geloggt

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -52,8 +52,8 @@ android {
         applicationId = "com.github.f1rlefanz.cf_alarmfortimeoffice"
         minSdk = 26
         targetSdk = 37
-        versionCode = 64
-        versionName = "1.15.1"
+        versionCode = 65
+        versionName = "1.15.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/util/UnusedAppRestrictionsHelper.kt
+++ b/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/util/UnusedAppRestrictionsHelper.kt
@@ -72,6 +72,12 @@ object UnusedAppRestrictionsHelper {
      */
     suspend fun isRestricted(context: Context): Boolean = try {
         needsPrompt(getUnusedAppRestrictionsStatusSuspend(context))
+    } catch (e: kotlinx.coroutines.CancellationException) {
+        // Rethrow for proper structured concurrency - callers run this in a Compose-tied
+        // scope (LaunchedEffect/rememberCoroutineScope) that cancels it whenever the user
+        // leaves the screen mid-check. That's normal lifecycle behavior, not a real error.
+        Logger.d(LogTags.UNUSED_APP_RESTRICTIONS, "Unused-app-restrictions check cancelled (left composition)")
+        throw e
     } catch (e: Exception) {
         Logger.e(LogTags.UNUSED_APP_RESTRICTIONS, "Failed to check unused-app-restrictions status", e)
         false

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -3,12 +3,13 @@
 **Lebendes Dokument.** Erledigtes wird gelöscht, nicht abgehakt oder durchgestrichen — was hier steht, ist offen.
 Die Historie steht im Git-Log, nicht hier.
 
-**Stand:** 22.07.2026 · `main` = **v1.15.1 / versionCode 64** · alles gemerged und gepusht.
+**Stand:** 22.07.2026 · `main` = **v1.15.2 / versionCode 65** · alles gemerged und gepusht.
 
 > **Ungeprüft:** der WLAN-Subnetz-Fix (v1.15.1) ist per Unit-Test gegen die realen Log-Fälle
 > (192.168.44.x, 10.0.9.x, CGNAT-Adresse) abgesichert und CI-grün, aber **nicht** am Gerät in
-> einem echten fremden WLAN bestätigt. Alles Übrige aus v1.15.0/v1.15.1 ist bereits am Gerät
-> bzw. im Log verifiziert.
+> einem echten fremden WLAN bestätigt. Der Log-Rauschen-Fix (v1.15.2) ist ein reiner
+> Cancellation-Rethrow nach etabliertem Codebase-Muster, unkritisch. Alles Übrige aus
+> v1.15.0/v1.15.1 ist bereits am Gerät bzw. im Log verifiziert.
 
 ---
 
@@ -30,15 +31,3 @@ WLAN oder auf Mobilfunk umschalten, während die Verbindung noch als „verbunde
    „Fehler"-Banner), bis man wirklich wieder im Heim-WLAN ist?
 3. Funktioniert die Lichtsteuerung wieder sofort, sobald man zurück im Heim-WLAN ist (kein
    unnötiger Reconnect-Zyklus)?
-
-### 2. Log-Rauschen bei „Nicht verwendete Apps"-Check
-
-Beim Prüfen der drei Logs aus Punkt 1 aufgefallen, aber bewusst nicht mit angefasst: Wenn man
-den Status-Tab verlässt, während `UnusedAppRestrictionsHelper.isRestricted()` noch läuft,
-wird die dabei entstehende `CancellationException` als `E/CFAlarm.UnusedAppRestrictions:
-Failed to check unused-app-restrictions status` samt zwei
-`LeftCompositionCancellationException`-Stacktraces geloggt. Funktional harmlos (fail-open,
-liefert dann `false`), aber irreführend fürs Log-Lesen. Ursache:
-`UnusedAppRestrictionsHelper.kt:73-78`, `catch (e: Exception)` fängt auch die normale
-Coroutine-Cancellation ab. Fix wäre, `CancellationException` separat durchzureichen statt zu
-loggen.

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -46,7 +46,18 @@
         </div>
 
         <div class="content-card">
-            <h3>🆕 Version 1.15.1 <small>(Aktuell – interne Alpha)</small></h3>
+            <h3>🆕 Version 1.15.2 <small>(Aktuell – interne Alpha)</small></h3>
+            <p><strong>Stand:</strong> Juli 2026</p>
+            <p><em>Ein irreführender Log-Eintrag beim Verlassen des Status-Tabs ist verschwunden.</em></p>
+
+            <h4>🐛 Behoben</h4>
+            <ul>
+                <li><strong>Falscher Fehler-Log beim „Nicht verwendete Apps"-Check:</strong> Verließ man den Status-Tab, während im Hintergrund geprüft wurde, ob die Android-Einschränkung aktiv ist, wurde der dabei normale Abbruch der Prüfung fälschlich als Fehler geloggt (samt zweier Compose-interner Stacktraces). Funktional ohne Auswirkung – die App verhielt sich schon vorher korrekt –, aber im Log sah es nach einem echten Problem aus. Jetzt wird ein Abbruch als das erkannt, was er ist.</li>
+            </ul>
+        </div>
+
+        <div class="content-card">
+            <h3>Version 1.15.1</h3>
             <p><strong>Stand:</strong> Juli 2026</p>
             <p><em>Der WLAN-Check vor dem Hue-Bridge-Zugriff erkennt jetzt auch ein falsches WLAN.</em></p>
 


### PR DESCRIPTION
## Summary

Zweite, kleinere Fehlerklasse aus derselben Log-Analyse wie PR #5 (Hue-WLAN-Fix, bereits gemergt): `UnusedAppRestrictionsHelper.isRestricted()` fing `CancellationException` im breiten `catch (e: Exception)` mit und loggte den normalen Coroutine-Abbruch beim Verlassen des Status-Tabs fälschlich als Fehler (`E/CFAlarm.UnusedAppRestrictions: Failed to check unused-app-restrictions status`, samt zwei `LeftCompositionCancellationException`-Stacktraces). 4x über zwei Tage in den Logs aufgetreten, funktional harmlos (fail-open), aber irreführendes Log-Rauschen.

Alle vier Aufrufer (`StatusTabContent.kt`, `MainScreen.kt` x3) liegen in Compose-Coroutine-Scopes (`LaunchedEffect`/`rememberCoroutineScope`), die beim Verlassen des Screens abgebrochen werden — genau dabei entsteht die `CancellationException`.

## Changes

- `UnusedAppRestrictionsHelper.isRestricted()`: `catch (e: CancellationException) { ...; throw e }` vor dem bestehenden `catch (e: Exception)` ergänzt — exakt das bereits mehrfach in der Codebase verwendete Muster (`AlarmViewModel.kt`, `OAuth2TokenManager.kt`, `HueMdnsDiscoveryService.kt`, `AuthViewModel.kt`). Kein Call-Site muss angepasst werden.
- Kein neuer Unit-Test: `UnusedAppRestrictionsHelperTest.kt` testet bewusst nur die reine `needsPrompt`-Zuordnung, nicht den dünnen Android-Wrapper `isRestricted` — dieselbe bestehende Konvention wie bei `BatteryOptimizationHelper`.
- Versions-Bump 1.15.1 → 1.15.2 (versionCode 64 → 65) + Changelog-Eintrag + `docs/HANDOFF.md` aktualisiert.

## Test plan

- [ ] `./gradlew testDebugUnitTest` / `lintDebug` / `assembleDebug` über CI (lokal in dieser Sitzung nicht ausführbar — Sandbox-Netzwerkzugriff auf `dl.google.com` blockiert)
- [ ] Log-Kontrolle nach dem nächsten Gerätelauf: beim Verlassen des Status-Tabs während des Checks sollte `D/CFAlarm.UnusedAppRestrictions: ... cancelled (left composition)` erscheinen statt des bisherigen `E/...Failed to check...` samt Stacktraces

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014TGcXPGYdVDYm3RaHiLbS4)_