### PR TITLE
fix(hue): Subnetz-Heuristik ist ein Hinweis, kein Veto

### DIFF
--- a/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/hue/connection/HueBridgeConnectionManager.kt
+++ b/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/hue/connection/HueBridgeConnectionManager.kt
@@ -19,6 +19,7 @@ import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -34,6 +35,7 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration.Companion.minutes
@@ -113,6 +115,13 @@ class HueBridgeConnectionManager private constructor(
         private val CONNECTION_CACHE_VALIDITY = 30.minutes  // Extended from 5 minutes
         private val FOREGROUND_HEALTH_CHECK_INTERVAL = 5.minutes  // Only when app visible
         private val BACKGROUND_HEALTH_CHECK_INTERVAL = 30.minutes  // Rare background checks
+
+        /**
+         * Deckel fuer einen Versuch, den die Subnetz-Heuristik fuer aussichtslos haelt.
+         * Deutlich kuerzer als die 10s von OkHttp: wer wirklich ausser Haus ist, soll nicht
+         * warten - aber eine Bridge hinter einem Router antwortet in Bruchteilen davon.
+         */
+        private val OFF_SUBNET_PROBE_TIMEOUT = 3.seconds
     }
     
     // Use WeakReference to prevent memory leaks
@@ -297,7 +306,15 @@ class HueBridgeConnectionManager private constructor(
                 // 30-min cache should survive the trip so no needless reconnect/health-check
                 // cycle fires the moment Wi-Fi is back, and the UI doesn't flash a misleading
                 // persistent error banner while just out of range.
-                if (!isBridgeReachableNow(currentState.bridgeIp)) {
+                // Die Subnetz-Pruefung ist ein HINWEIS, kein Urteil - deshalb hier kein blindes
+                // Abbrechen mehr, sondern ein kurz gedeckelter echter Versuch (siehe
+                // [probeBridge]: Gast-WLAN/VLAN/Mesh/Doppel-NAT/Emulator erreichen die Bridge,
+                // ohne im selben Subnetz zu liegen). Nur wenn AUCH der scheitert, gilt sie als
+                // unerreichbar. Der teure Fall bleibt damit billig: wer wirklich ausser Haus
+                // ist, wartet OFF_SUBNET_PROBE_TIMEOUT statt der vollen 10s.
+                if (!isBridgeReachableNow(currentState.bridgeIp) &&
+                    !probeBridge(currentState.bridgeIp, currentState.username)
+                ) {
                     Logger.w(LogTags.HUE_BRIDGE, "⚠️ BRIDGE-MANAGER: Cached bridge ${currentState.bridgeIp} not reachable from current network, skipping live connection attempt")
                     throw IllegalStateException("Bridge unreachable: not on the bridge's local network (${currentState.bridgeIp})")
                 }
@@ -609,23 +626,77 @@ class HueBridgeConnectionManager private constructor(
     }
 
     /**
-     * INTERNAL: Validate connection credentials against bridge
+     * INTERNAL: Fragt die Bridge WIRKLICH - [isBridgeReachableNow] ist dabei nur ein Hinweis
+     * darauf, wie lange sich das Warten lohnt, NICHT das Urteil.
+     *
+     * **Warum das wichtig ist:** Die Subnetz-Prüfung verlangt, dass das Gerät eine eigene IPv4
+     * im selben Subnetz wie die Bridge hat. Das ist im Normalfall („zu Hause im WLAN" gegen
+     * „unterwegs") eine gute, billige Abkürzung — aber es ist eine HEURISTIK, und sie liefert
+     * Falsch-Negative überall dort, wo ein Router zwischen zwei erreichbaren Netzen vermittelt:
+     * Gast-WLAN, getrenntes VLAN, Mesh-/Repeater-Setups mit eigenem Subnetz, Doppel-NAT — und
+     * der Android-Emulator, der über NAT (10.0.2.x) durchaus ins Heimnetz routet.
+     *
+     * Vorher war die Heuristik ein VETO **vor** dem echten Test, und genau das ist am
+     * 13.08.2026 am Emulator aufgeschlagen: das Pairing bekam eine HTTPS **200** von der
+     * Bridge, und 7 ms später verwarf `validateConnectionCredentials()` dieselbe Bridge mit
+     * „not reachable from current network". Der Nutzer sah „Bridge connection validation
+     * failed" und hatte keinen Weg, das zu übergehen — eine antwortende Bridge, abgelehnt von
+     * einer Vermutung über sie.
+     *
+     * Der echte Request ist das einzige belastbare Urteil. Die Heuristik entscheidet nur noch,
+     * ob wir dem Versuch das volle OkHttp-Timeout (10 s) zugestehen oder ihn nach
+     * [OFF_SUBNET_PROBE_TIMEOUT] abschneiden. Damit bleibt der ursprüngliche Zweck erhalten —
+     * kein langer Hänger, wenn man tatsächlich außer Haus ist — ohne eine erreichbare Bridge
+     * auszusperren.
      */
-    private suspend fun validateConnectionCredentials(bridgeIp: String, username: String): Boolean {
-        if (!isBridgeReachableNow(bridgeIp)) {
-            Logger.w(LogTags.HUE_BRIDGE, "⚠️ BRIDGE-MANAGER: $bridgeIp not reachable from current network (off home Wi-Fi or wrong subnet), skipping bridge connection")
-            return false
+    private suspend fun probeBridge(bridgeIp: String, username: String): Boolean {
+        val sameSubnet = isBridgeReachableNow(bridgeIp)
+        if (!sameSubnet) {
+            Logger.w(
+                LogTags.HUE_BRIDGE,
+                "⚠️ BRIDGE-MANAGER: $bridgeIp liegt in keinem lokalen IPv4-Subnetz dieses Geraets " +
+                    "(vermutlich ausser Haus) - Versuch trotzdem, gedeckelt auf ${OFF_SUBNET_PROBE_TIMEOUT.inWholeSeconds}s"
+            )
         }
-
         return try {
-            apiClient.getBridgeConfig(bridgeIp, username)
-            Logger.d(LogTags.HUE_BRIDGE, "✅ BRIDGE-MANAGER: Connection validation successful")
-            true
+            if (sameSubnet) {
+                apiClient.getBridgeConfig(bridgeIp, username)
+                Logger.d(LogTags.HUE_BRIDGE, "✅ BRIDGE-MANAGER: Connection validation successful")
+                true
+            } else {
+                // withTimeoutOrNull statt withTimeout: ein Ablauf ist hier ein normales
+                // Ergebnis ("nicht erreichbar"), kein Fehler.
+                val ok = withTimeoutOrNull(OFF_SUBNET_PROBE_TIMEOUT) {
+                    apiClient.getBridgeConfig(bridgeIp, username)
+                    true
+                }
+                if (ok == true) {
+                    Logger.i(
+                        LogTags.HUE_BRIDGE,
+                        "✅ BRIDGE-MANAGER: Bridge trotz fremden Subnetzes erreichbar - die Heuristik lag falsch, " +
+                            "der echte Request entscheidet"
+                    )
+                    true
+                } else {
+                    Logger.d(LogTags.HUE_BRIDGE, "❌ BRIDGE-MANAGER: $bridgeIp auch im Kurzversuch nicht erreichbar")
+                    false
+                }
+            }
+        } catch (e: CancellationException) {
+            // Weiterwerfen: eine Cancellation ist keine Aussage ueber die Bridge, sondern das
+            // Ende der umgebenden Coroutine (siehe CLAUDE.md, "Fehlerbehandlung").
+            throw e
         } catch (e: Exception) {
             Logger.d(LogTags.HUE_BRIDGE, "❌ BRIDGE-MANAGER: Connection validation failed: ${e.message}")
             false
         }
     }
+
+    /**
+     * INTERNAL: Validate connection credentials against bridge
+     */
+    private suspend fun validateConnectionCredentials(bridgeIp: String, username: String): Boolean =
+        probeBridge(bridgeIp, username)
     
     /**
      * OPTIMIZATION: Smart health monitoring - Event-driven instead of continuous polling

--- a/app/src/test/java/com/github/f1rlefanz/cf_alarmfortimeoffice/hue/connection/HueBridgeConnectionManagerTest.kt
+++ b/app/src/test/java/com/github/f1rlefanz/cf_alarmfortimeoffice/hue/connection/HueBridgeConnectionManagerTest.kt
@@ -16,8 +16,11 @@ import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.stub
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.util.concurrent.atomic.AtomicBoolean
@@ -29,10 +32,21 @@ import java.util.concurrent.atomic.AtomicBoolean
  * to the Hue Bridge - and waiting out a 10s [java.net.SocketTimeoutException] - even though the
  * phone was demonstrably not on the bridge's network. That happened because the cached
  * `ConnectionState.CONNECTED` fast path in `getValidatedConnection()` returned the bridge
- * IP/credentials with no reachability check at all. These tests lock in the fix: when
- * [NetworkStateMonitor.isReachableSubnet] says the bridge isn't reachable, the manager must
- * fail fast WITHOUT ever calling the real API client, and must not downgrade the cached
- * connection state (a transient "wrong network" isn't a bridge/credential failure).
+ * IP/credentials with no reachability check at all.
+ *
+ * NACHGESCHAERFT (v1.24.x): Der erste Fix machte [NetworkStateMonitor.isReachableSubnet] zum
+ * VETO - "fail fast WITHOUT ever calling the real API client". Das ging zu weit. Die Pruefung
+ * verlangt eine eigene IPv4 im selben Subnetz und liefert Falsch-Negative, sobald ein Router
+ * zwischen zwei erreichbaren Netzen vermittelt: Gast-WLAN, getrenntes VLAN, Mesh mit eigenem
+ * Subnetz, Doppel-NAT - und der Emulator, der ueber NAT (10.0.2.x) sehr wohl ins Heimnetz
+ * routet. Am 13.08.2026 real aufgeschlagen: das Pairing bekam eine HTTPS 200 von der Bridge,
+ * und Millisekunden spaeter verwarf die Validierung genau diese Bridge als "not reachable".
+ *
+ * Heutige Zusicherung: die Heuristik entscheidet ueber das TIMEOUT, nicht ueber das Ergebnis.
+ * Off-subnet wird ein KURZ gedeckelter echter Versuch gemacht; nur wenn auch der scheitert,
+ * gilt die Bridge als unerreichbar. Der urspruengliche Zweck (kein 10s-Haenger ausser Haus)
+ * bleibt erhalten, ebenso das Nicht-Herabstufen des Verbindungszustands - ein transientes
+ * "falsches Netz" ist kein Bridge-/Zugangsdaten-Fehler.
  */
 class HueBridgeConnectionManagerTest {
 
@@ -152,16 +166,59 @@ class HueBridgeConnectionManagerTest {
     // is a `verify(mock).suspendFun(...)` call would otherwise infer a non-Unit return type
     // (the suspend function's return type), which JUnit4 rejects with InvalidTestClassError.
 
+    /**
+     * ABGELOEST die fruehere Zusicherung "off-subnet wirft, OHNE den API-Client je aufzurufen".
+     *
+     * Die alte Fassung schrieb fest, dass die Subnetz-Heuristik ein VETO ist. Genau das war der
+     * Fehler: `isReachableSubnet()` verlangt eine eigene IPv4 im selben Subnetz und liefert
+     * Falsch-Negative bei Gast-WLAN, getrenntem VLAN, Mesh mit eigenem Subnetz, Doppel-NAT und
+     * am Emulator (NAT 10.0.2.x, routet aber ins Heimnetz). Am 13.08.2026 real aufgeschlagen:
+     * das Pairing bekam eine HTTPS 200 von der Bridge, und Millisekunden spaeter verwarf die
+     * Validierung dieselbe Bridge als "not reachable" - eine antwortende Bridge, abgelehnt von
+     * einer Vermutung ueber sie.
+     *
+     * Die Heuristik entscheidet jetzt nur noch ueber das TIMEOUT. Der echte Request ist das
+     * Urteil - deshalb wird er auch off-subnet versucht.
+     */
     @Test
-    fun `off-subnet cached connection throws without ever calling the real API client`() {
+    fun `off-subnet - der echte Request wird trotzdem versucht, nicht uebersprungen`() {
         runBlocking {
             val (manager, _, apiClient) = buildManager(isReachable = false)
+
+            runCatching { manager.getValidatedConnection() }
+
+            // Der Kern der Aenderung: GENAU EIN echter Versuch statt null.
+            verify(apiClient, times(1)).getBridgeConfig(any(), any())
+        }
+    }
+
+    /** Scheitert auch der Kurzversuch, bleibt es beim alten, richtigen Ausgang. */
+    @Test
+    fun `off-subnet - scheitert auch der Kurzversuch, wird geworfen`() {
+        runBlocking {
+            val (manager, _, apiClient) = buildManager(isReachable = false)
+            apiClient.stub {
+                onBlocking { getBridgeConfig(any(), any()) } doAnswer { throw java.io.IOException("no route") }
+            }
 
             assertThrows(IllegalStateException::class.java) {
                 runBlocking { manager.getValidatedConnection() }
             }
+        }
+    }
 
-            verify(apiClient, never()).getBridgeConfig(any(), any())
+    /**
+     * Der eigentliche Zweck des Fixes: antwortet die Bridge, gilt sie als erreichbar - auch wenn
+     * die Subnetz-Heuristik das Gegenteil behauptet.
+     */
+    @Test
+    fun `off-subnet - antwortet die Bridge trotzdem, wird die Verbindung benutzt`() {
+        runBlocking {
+            val (manager, _, _) = buildManager(isReachable = false)
+
+            val (returnedIp, returnedUser) = manager.getValidatedConnection()
+
+            assertTrue(returnedIp == bridgeIp && returnedUser == username)
         }
     }
 


### PR DESCRIPTION
Am Emulator reproduziert (13.08.2026): Die Bridge-Einrichtung schlug mit
„Bridge connection validation failed" fehl, **obwohl das Pairing 7 ms zuvor eine HTTPS 200 von
genau dieser Bridge bekommen hatte**:

```
10:43:44.365  ✅ Secure HTTPS request successful: 200
10:43:44.372  ⚠️ 192.168.178.24 not reachable ... skipping bridge connection
10:43:44.372  ❌ Bridge connection validation failed
```

## Ursache

`validateConnectionCredentials()` fragte `isBridgeReachableNow()` als **Veto, bevor** der
eigentliche Test lief. Die Prüfung dahinter (`NetworkStateMonitor.isReachableSubnet`) verlangt,
dass das Gerät eine eigene IPv4 im **selben Subnetz** wie die Bridge hat.

Als Abkürzung für „zu Hause vs. unterwegs" ist das brauchbar — aber es ist eine Heuristik, und sie
liefert Falsch-Negative überall dort, wo ein Router zwischen zwei erreichbaren Netzen vermittelt:
Gast-WLAN, getrenntes VLAN, Mesh-/Repeater-Setups mit eigenem Subnetz, Doppel-NAT. Und am
Emulator: der hängt an `10.0.2.15/24` hinter NAT, routet aber nachweislich ins Heimnetz
(`ping 192.168.178.24` → 0 % Verlust).

## Änderung

Der echte Request ist das einzige belastbare Urteil. Die Heuristik entscheidet jetzt nur noch, ob
der Versuch das volle OkHttp-Timeout (10 s) bekommt oder nach `OFF_SUBNET_PROBE_TIMEOUT` (3 s)
abgeschnitten wird. Der ursprüngliche Zweck — kein langer Hänger, wenn man wirklich außer Haus ist
— bleibt damit erhalten, ohne eine antwortende Bridge auszusperren.

**Beide** Aufrufstellen umgestellt; sonst hätte das Setup verbunden und jede spätere Nutzung wäre
weiter an derselben Heuristik gescheitert. Unverändert bleibt, dass der Verbindungszustand dabei
**nicht** auf `ERROR` herabgestuft wird (ein transientes „falsches Netz" ist kein Bridge- oder
Zugangsdaten-Fehler).

## Tests

Die bisherige Zusicherung hieß „off-subnet wirft, **ohne** den API-Client je aufzurufen" — sie
schrieb also genau das Veto fest und ist abgelöst. An ihre Stelle treten drei Fälle, die die neue
Zusicherung in **beide** Richtungen halten: es wird genau *ein* echter Versuch gemacht (nicht
null); scheitert auch der, wird geworfen; antwortet die Bridge trotzdem, wird die Verbindung
benutzt. Der Klassen-KDoc ist mitgezogen, sonst widerspräche die Datei sich selbst.

**606 Tests grün**, Lint 0 errors / 0 warnings / 3 hints.

## Offen

Am Gerät läuft die Kette jetzt bis zum echten Bridge-Dialog durch — der Fehler lautet nur noch
„Link button not pressed" (eine echte Antwort der Bridge). Die abschließende Kopplung braucht
einen physischen Druck auf die Link-Taste und steht noch aus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)