### PR TITLE
Dimmer-Benachrichtigung fuehrt zur Bedienungshilfen-Karte und von dort direkt zum Dienst

### DIFF
--- a/.claude/skills/cfalarm-dimmer-und-dnd/SKILL.md
+++ b/.claude/skills/cfalarm-dimmer-und-dnd/SKILL.md
@@ -117,6 +117,13 @@ das baut man dieselbe Falle in neuer Form nach.
   Entscheidung in `DimDiagnostik.dimmenWirkungslos()`, bewusst nur bei aktivem, nicht pausiertem
   Fenster. Vorher stand der Dienst-Zustand NUR in einer DEBUG-Zeile, während die Benachrichtigung
   einen Verdunkelungswert behauptete — Hergang in `reference/dimmer.md`.
+- **Und dieser Hinweis muss AN DIE STELLE FÜHREN, an der man ihn auflöst.** Ein Tipp darauf öffnet
+  den Status-Tab, rollt die Bedienungshilfen-Karte ins Bild und zeigt deren Offenlegung; ihr Knopf
+  springt direkt auf die Detailseite DIESES Dienstes (`ACTION_ACCESSIBILITY_DETAILS_SETTINGS`, ab
+  Android 11, Rückfall auf die Liste). **Die Offenlegung bleibt dazwischen** — der direkte Sprung
+  aus der Benachrichtigung ginge an der Play-Pflicht vorbei, und genau deshalb hat der Weg zwei
+  Stationen statt einer. Signalweg und seine vier Fallen (SINGLE_TOP, `setIntent()`,
+  `savedInstanceState == null`, Zähler statt Boolean) in `reference/dimmer.md`.
 - **Das Verschwinden des Dienstes ist nicht protokollierbar — die RÜCKKEHR schon.** Bei einem
   `SIGKILL` (App-Update, Speicherdruck, Absturz) läuft weder `onUnbind` noch `onDestroy`. Deshalb
   setzt `onServiceConnected()` einen SharedPreferences-Merker (`commit()`, nicht `apply()`), den

--- a/.claude/skills/cfalarm-dimmer-und-dnd/reference/dimmer.md
+++ b/.claude/skills/cfalarm-dimmer-und-dnd/reference/dimmer.md
@@ -64,7 +64,7 @@
   **Ausgelöst hat den Umbau der gemeldete Fehler vom 23.08.2026** — gedimmter Bildschirm und
   laufendes „Nicht stören" um 08:48 nach einem Spätdienst-Wecker 12:30; Hergang und Messung stehen
   beim Ende-Anker `ALARM_SONST_CLOCK` weiter unten und werden hier nicht wiederholt. Er schloss die
-  Ausdrucklücke und machte damit zugleich den Nacht-Standard entbehrlich: ein Fenster
+  Ausdruckslücke und machte damit zugleich den Nacht-Standard entbehrlich: ein Fenster
   `CLOCK 22:00 → ALARM_SONST_CLOCK 07:00` IST der komplette Nacht-Standard, für jede Kalendernacht,
   als EIN Fenster — ohne das Paar aus Rückwärts- und Vorwärts-Fenster und ohne die
   Folgetag-Bedingung `nextDayCoversTonight`, die auf ein ANDERES Datum schaut und deren erster Wurf
@@ -352,7 +352,7 @@
   Testen zwischen Versionen springt, muss es kennen, sonst sieht es wie ein kaputtes Loeschen aus.
 - **Das Verschwinden des Overlays muss eine Spur hinterlassen (seit v1.34.1) — und der Vorfall,
   der das erzwang, war KEIN App-Fehler.** Am 24.08.2026 meldete der Eigentuemer, der Bildschirm sei
-  waehrend einer per adb ferngesteuerten Sitzung „mail heller und mal dunkler" geworden. Ursache
+  waehrend einer per adb ferngesteuerten Sitzung „mal heller und mal dunkler" geworden. Ursache
   gemessen: `uiautomator` verbindet sich als `UiAutomation` und **unterdrueckt dabei alle anderen
   Bedienungshilfen-Dienste**, also auch `DimAccessibilityService`. Beleg: die SurfaceFlinger-Layer-ID
   des `CFAlarmDimLayer` wechselte bei JEDEM Automations-Aufruf (64604 → 64609 → 64614), im Leerlauf
@@ -547,3 +547,4 @@
 - **`DimCorrectionNotifier.show()` prüft `NotificationManagerCompat.areNotificationsEnabled()`
   vor `notify()`** (Fix v1.22.1) — ohne POST_NOTIFICATIONS-Berechtigung verschluckt `notify()` sonst
   lautlos, ohne Log oder Exception, und sieht im Logcat identisch aus wie der obige Toggle-Bug.
+

--- a/.claude/skills/cfalarm-dimmer-und-dnd/reference/dimmer.md
+++ b/.claude/skills/cfalarm-dimmer-und-dnd/reference/dimmer.md
@@ -64,7 +64,7 @@
   **Ausgelöst hat den Umbau der gemeldete Fehler vom 23.08.2026** — gedimmter Bildschirm und
   laufendes „Nicht stören" um 08:48 nach einem Spätdienst-Wecker 12:30; Hergang und Messung stehen
   beim Ende-Anker `ALARM_SONST_CLOCK` weiter unten und werden hier nicht wiederholt. Er schloss die
-  Ausdruckslücke und machte damit zugleich den Nacht-Standard entbehrlich: ein Fenster
+  Ausdrucklücke und machte damit zugleich den Nacht-Standard entbehrlich: ein Fenster
   `CLOCK 22:00 → ALARM_SONST_CLOCK 07:00` IST der komplette Nacht-Standard, für jede Kalendernacht,
   als EIN Fenster — ohne das Paar aus Rückwärts- und Vorwärts-Fenster und ohne die
   Folgetag-Bedingung `nextDayCoversTonight`, die auf ein ANDERES Datum schaut und deren erster Wurf
@@ -352,7 +352,7 @@
   Testen zwischen Versionen springt, muss es kennen, sonst sieht es wie ein kaputtes Loeschen aus.
 - **Das Verschwinden des Overlays muss eine Spur hinterlassen (seit v1.34.1) — und der Vorfall,
   der das erzwang, war KEIN App-Fehler.** Am 24.08.2026 meldete der Eigentuemer, der Bildschirm sei
-  waehrend einer per adb ferngesteuerten Sitzung „mal heller und mal dunkler" geworden. Ursache
+  waehrend einer per adb ferngesteuerten Sitzung „mail heller und mal dunkler" geworden. Ursache
   gemessen: `uiautomator` verbindet sich als `UiAutomation` und **unterdrueckt dabei alle anderen
   Bedienungshilfen-Dienste**, also auch `DimAccessibilityService`. Beleg: die SurfaceFlinger-Layer-ID
   des `CFAlarmDimLayer` wechselte bei JEDEM Automations-Aufruf (64604 → 64609 → 64614), im Leerlauf
@@ -484,6 +484,39 @@
   Dimmer-Meldungen nebeneinander wären genau die Doppelaussage, die hier korrigiert wird. Am Emulator
   beidseitig belegt (Fenster 22:00–07:00, Zeit 23:30): Dienst nicht gebunden ⇒ `actions=0` und genau
   ein WARN; Dienst gebunden ⇒ „Verdunkelung: 55 %, Wärme: 40 %", `actions=3`, kein WARN.
+- **Die Meldung sagte, WAS zu tun ist — nicht, WO (04.09.2026).** Der Eigentümer fragte, ob die
+  Benachrichtigung „nicht direkt zum Bedienungshilfen-aktivieren-Ort verlinken kann, oder
+  wenigstens auf die Karte in der App". Der Hinweis endete mit „Zum Aktivieren tippen", und der
+  Tipp öffnete die App — auf dem zuletzt benutzten Tab. Die Karte, die den Dienst aktivieren
+  lässt, steht im Status-Tab unterhalb von sechs anderen; am Ende derselben Kette öffnete ihr
+  Knopf die Liste **aller** Bedienungshilfen, in der der Eintrag der App zwischen Systemdiensten
+  steht. Beide Enden waren also formal richtig und praktisch eine Schnitzeljagd — dieselbe Klasse
+  Fehler wie oben, nur eine Ebene weiter: die Meldung stimmte, ihr Ausweg war unbenutzbar.
+
+  **Direkt in die Android-Einstellungen zu springen bleibt verboten** — davor gehört die
+  Play-Pflicht-Offenlegung, und die zeigt nur die Karte. Deshalb hat der Weg bewusst zwei
+  Stationen: Das Extra `MainActivity.EXTRA_EINSTIEG` sagt der Activity, WESHALB geöffnet wurde;
+  sie stellt den Wunsch (`DimBedienungshilfenWunsch`) und wechselt auf den Status-Tab, der rollt
+  die Karte ins Bild und lässt sie die Offenlegung zeigen. **Erst deren Knopf** springt — seit
+  jetzt über `ACTION_ACCESSIBILITY_DETAILS_SETTINGS` (ab Android 11) direkt auf die Seite DIESES
+  Dienstes, mit Rückfall auf die Liste, weil das Detail-Ziel nicht auf jedem Gerät existiert.
+
+  Vier Fallen stecken in den Details, alle nicht offensichtlich: `FLAG_ACTIVITY_CLEAR_TOP` **ohne**
+  `FLAG_ACTIVITY_SINGLE_TOP` legt die laufende MainActivity (Start-Modus `standard`) neu an statt
+  ihr `onNewIntent` zu geben — der Nutzer verlöre seinen Stand; `onNewIntent` ohne `setIntent()`
+  lässt `getIntent()` weiter den Start-Intent liefern (dieselbe Falle wie am Weckbildschirm); die
+  Auswertung in `onCreate` gehört hinter `savedInstanceState == null`, sonst schickt **jede
+  Drehung** den Nutzer erneut auf den Status-Tab; und das Signal an die Karte ist ein ZÄHLER, kein
+  Boolean — ein Rückkanal „verbraucht" wäre als `LaunchedEffect`-Schlüssel gerade der Wert, der
+  den noch laufenden Bildlauf mittendrin abbräche. Das Bildlaufziel wird aus
+  `positionInRoot()` von Karte und Spalte plus dem aktuellen Stand gerechnet: der reine Abstand im
+  Fenster verschiebt sich beim Rollen mit.
+
+  **Am Gerät noch nicht belegt** (die Sitzung, die es gebaut hat, hatte weder Emulator noch SDK).
+  Zu prüfen ist genau zweierlei: dass die Detailseite auf dem Fairphone wirklich mit dem Eintrag
+  der App öffnet (sonst greift der Rückfall, und der ist die Liste von vorher), und dass der
+  Bildlauf die Karte trifft, wenn die App aus der Benachrichtigung KALT startet — dort läuft der
+  Effekt vor dem ersten Layout-Durchgang und wartet auf die Vermessung.
 - **„Kurz hell, dann von allein wieder dunkel" — warum das Verschwinden NIE im App-Log stehen kann
   (29.08.2026).** Unmittelbar nach dem obigen Fix meldete der Eigentümer beim Einspielen der neuen
   Version genau das. Im Systemlog stand der Grund lückenlos: `23:06:07.619 Killing 18584 … due to
@@ -514,4 +547,3 @@
 - **`DimCorrectionNotifier.show()` prüft `NotificationManagerCompat.areNotificationsEnabled()`
   vor `notify()`** (Fix v1.22.1) — ohne POST_NOTIFICATIONS-Berechtigung verschluckt `notify()` sonst
   lautlos, ohne Log oder Exception, und sieht im Logcat identisch aus wie der obige Toggle-Bug.
-

--- a/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/MainActivity.kt
+++ b/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/MainActivity.kt
@@ -25,9 +25,11 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.github.f1rlefanz.cf_alarmfortimeoffice.auth.manager.CalendarPermissionOutcome
 import com.github.f1rlefanz.cf_alarmfortimeoffice.auth.manager.OAuth2TokenManager
+import com.github.f1rlefanz.cf_alarmfortimeoffice.dimmer.DimBedienungshilfenWunsch
 import com.github.f1rlefanz.cf_alarmfortimeoffice.dimmer.DimmerModellMigration
 import com.github.f1rlefanz.cf_alarmfortimeoffice.dnd.DndScheduleUseCase
 import com.github.f1rlefanz.cf_alarmfortimeoffice.hue.connection.HueBridgeConnectionManager
+import com.github.f1rlefanz.cf_alarmfortimeoffice.navigation.MainTab
 import com.github.f1rlefanz.cf_alarmfortimeoffice.ui.components.LoadingScreen
 import com.github.f1rlefanz.cf_alarmfortimeoffice.ui.screens.CalendarAuthorizationScreen
 import com.github.f1rlefanz.cf_alarmfortimeoffice.ui.screens.LoginScreen
@@ -59,6 +61,24 @@ import javax.inject.Inject
  */
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+    companion object {
+        /**
+         * Sagt, WESHALB die App geoeffnet wurde. Eine Benachrichtigung, die auf einen Zustand
+         * hinweist, muss auch an die Stelle fuehren, an der man ihn aendert - sonst schickt sie
+         * den Nutzer auf die Suche. Gesetzt wird das Extra vom Absender der Meldung, ausgewertet
+         * in [verarbeiteEinstieg].
+         */
+        const val EXTRA_EINSTIEG = "com.github.f1rlefanz.cf_alarmfortimeoffice.EINSTIEG"
+
+        /**
+         * „Der Schicht-Dimmer kann nicht dimmen, weil der Bedienungshilfen-Dienst aus ist" -
+         * gesetzt von `DimCorrectionNotifier.appIntent()`. Ziel ist der Status-Tab mit seiner
+         * Bedienungshilfen-Karte, nicht die Android-Einstellung selbst: davor gehoert die
+         * Play-Pflicht-Offenlegung, die die Karte zeigt.
+         */
+        const val EINSTIEG_DIMMER_BEDIENUNGSHILFEN = "dimmer_bedienungshilfen"
+    }
 
     // Hilt injected dependencies
     @Inject lateinit var oauth2TokenManager: OAuth2TokenManager
@@ -135,6 +155,14 @@ class MainActivity : ComponentActivity() {
                         .onFailure { Logger.w(LogTags.DND, "⚠️ DND-Kette nach der Dimmer-Migration nicht neu armiert", it) }
                 }
             }
+        }
+
+        // NUR beim ECHTEN Erststart dieser Activity, nicht nach einer Drehung: `onCreate` laeuft
+        // dann mit DEMSELBEN Intent erneut, und der Nutzer landete jedes Mal wieder auf dem
+        // Status-Tab - auch wenn er laengst woanders war. Nach Prozesstod und Wiederherstellung
+        // (savedInstanceState != null) gilt dasselbe: der Wunsch von damals ist erledigt.
+        if (savedInstanceState == null) {
+            verarbeiteEinstieg(intent)
         }
 
         // POST_NOTIFICATIONS wird NICHT mehr hier (vor dem Login, kontextlos) abgefragt, sondern
@@ -256,6 +284,43 @@ class MainActivity : ComponentActivity() {
         
         // PHASE 2: Initialize Smart Scheduling on app startup
         Logger.d(LogTags.LIFECYCLE, "MainActivity: Initializing Hue Smart Scheduling system")
+    }
+
+    /**
+     * Die App laeuft bereits, und eine Benachrichtigung schickt sie an eine bestimmte Stelle.
+     *
+     * `setIntent()` ist Pflicht, nicht Kosmetik: ohne den Aufruf liefert `getIntent()` weiterhin
+     * den Start-Intent - jede spaetere Auswertung (auch die nach einer Drehung) laese dann das
+     * ALTE Ziel. Dieselbe Falle wie am Weckbildschirm, siehe
+     * [AlarmFullScreenActivity.onNewIntent].
+     */
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        verarbeiteEinstieg(intent)
+    }
+
+    /**
+     * Setzt den Einstiegswunsch aus einer Benachrichtigung in Navigation um.
+     *
+     * Der Wunsch wird gestellt, BEVOR der Tab gewechselt wird - der Status-Tab wertet ihn beim
+     * ersten Zeichnen aus, und ein noch nicht gestellter Wunsch waere dann schlicht nicht da.
+     * Fuehrt ein Onboarding-Gate oder der Login-Screen den Nutzer zuerst woandershin, bleibt der
+     * Wunsch stehen und wird eingeloest, sobald der Status-Tab wirklich erscheint.
+     */
+    private fun verarbeiteEinstieg(intent: Intent?) {
+        when (intent?.getStringExtra(EXTRA_EINSTIEG)) {
+            EINSTIEG_DIMMER_BEDIENUNGSHILFEN -> {
+                Logger.business(
+                    LogTags.NAVIGATION,
+                    "Einstieg aus der Dimmer-Benachrichtigung -> Status-Tab, Bedienungshilfen-Karte"
+                )
+                DimBedienungshilfenWunsch.stellen()
+                navigationViewModel.navigateToMainWithTab(MainTab.STATUS)
+            }
+
+            else -> Unit
+        }
     }
 
     private fun checkNotificationPermission() {

--- a/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/dimmer/DimBedienungshilfenWunsch.kt
+++ b/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/dimmer/DimBedienungshilfenWunsch.kt
@@ -1,0 +1,47 @@
+package com.github.f1rlefanz.cf_alarmfortimeoffice.dimmer
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Einmal-Signal: „Der Nutzer hat die Dimmer-Benachrichtigung angetippt, um den
+ * Bedienungshilfen-Dienst zu aktivieren."
+ *
+ * WOZU: Die Benachrichtigung „Dimmt nicht — Bedienungshilfen-Dienst ist aus" (siehe
+ * [DimCorrectionNotifier]) fuehrt bewusst NICHT direkt in die Android-Einstellungen, sondern in
+ * die App — davor gehoert die Play-Pflicht-Offenlegung, die die Karte im Status-Tab zeigt. Damit
+ * das ein Ausweg und keine Schnitzeljagd ist, muss die Oberflaeche erfahren, WESHALB die App
+ * gerade geoeffnet wurde: nur so kann sie zur richtigen Karte rollen und die Offenlegung
+ * anbieten. Ohne dieses Signal landet der Nutzer irgendwo im Status-Tab, waehrend die Karte, die
+ * er sucht, unterhalb von sechs anderen steht.
+ *
+ * WARUM EIN PROZESSWEITES OBJEKT UND KEIN DURCHGEREICHTER PARAMETER: Die Karte liest den
+ * Dienst-Zustand ohnehin direkt an der Quelle ([DimAccessibilityService.isRunning]) statt ihn
+ * durch drei Composables zu schleusen, die mit dem Dimmer nichts zu tun haben; dieses Signal
+ * nimmt denselben Weg. Ein ViewModel-Feld waere die Alternative gewesen — es haette
+ * `MainScreen` und `MainContentScreen` je zwei Parameter mehr gegeben, ohne dass einer der
+ * beiden davon etwas wuesste.
+ *
+ * EINMAL heisst einmal: [verbrauchen] wird von der ersten Stelle gerufen, die das Signal
+ * auswertet (dem Status-Tab). Bleibt es stehen, weil der Nutzer den Status-Tab gar nicht
+ * erreicht (Onboarding-Gate, Login), verfaellt es spaetestens mit dem Prozess — es gibt also
+ * keinen Zustand, der sich hier ansammeln koennte.
+ */
+object DimBedienungshilfenWunsch {
+
+    private val _offen = MutableStateFlow(false)
+
+    /** `true`, solange ein Aktivierungswunsch auf seine Auswertung wartet. */
+    val offen: StateFlow<Boolean> = _offen.asStateFlow()
+
+    /** Aus dem Einstieg heraus gerufen (siehe `MainActivity.verarbeiteEinstieg`). */
+    fun stellen() {
+        _offen.value = true
+    }
+
+    /** Von der auswertenden Oberflaeche gerufen, bevor sie handelt. */
+    fun verbrauchen() {
+        _offen.value = false
+    }
+}

--- a/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/dimmer/DimCorrectionNotifier.kt
+++ b/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/dimmer/DimCorrectionNotifier.kt
@@ -51,8 +51,8 @@ class DimCorrectionNotifier @Inject constructor(
      * eine Verdunkelung zu behaupten (Vorfall 29.08.2026, Hergang in
      * [DimDiagnostik.dimmenWirkungslos]). Die drei Korrektur-Knoepfe entfallen in dem Fall
      * bewusst: sie wuerden ein Overlay heller/dunkler stellen, das es nicht gibt. An ihre Stelle
-     * tritt ein Tipp-Ziel in die App, wo die Status-Karte den Dienst aktivieren laesst — eine
-     * Meldung ohne Ausweg waere nur halb so viel wert.
+     * tritt ein Tipp-Ziel auf die Status-Karte, die den Dienst aktivieren laesst (siehe
+     * [appIntent]) — eine Meldung ohne Ausweg waere nur halb so viel wert.
      */
     fun show(strength: Int, warmth: Int, paused: Boolean, dienstGebunden: Boolean) {
         createNotificationChannelIfNeeded()
@@ -176,13 +176,34 @@ class DimCorrectionNotifier @Inject constructor(
      * Tipp-Ziel des Dienst-fehlt-Hinweises: die App selbst. Der Sprung direkt in die
      * Bedienungshilfen-Einstellungen waere kuerzer, ginge aber an der Play-Pflicht-Offenlegung
      * vorbei, die die Status-Karte vor dem Aktivieren zeigt (siehe `DimmerAccessibilityCard`).
+     *
+     * ABER NICHT NUR „die App": das Extra sagt MainActivity, WESHALB geoeffnet wurde, und die
+     * fuehrt damit auf den Status-Tab, rollt die Bedienungshilfen-Karte ins Bild und laesst sie
+     * die Offenlegung zeigen. Ohne das Extra endete der Tipp auf dem zuletzt benutzten Tab, und
+     * die Karte, um die es geht, stand ungesehen weiter unten — eine Meldung mit Ausweg, den
+     * man suchen muss, ist nur die halbe Meldung. Von der Offenlegung aus geht es dann direkt auf
+     * die Detailseite DIESES Dienstes (siehe `openAccessibilitySettings`), nicht in die lange
+     * Liste aller Bedienungshilfen.
+     *
+     * `FLAG_ACTIVITY_SINGLE_TOP` gehoert zwingend dazu: ohne es wirft `FLAG_ACTIVITY_CLEAR_TOP`
+     * eine bereits laufende MainActivity (Start-Modus `standard`) weg und legt sie neu an — der
+     * Nutzer verlaere dabei den Zustand, in dem er die App zuletzt verlassen hat. Mit dem Flag
+     * bekommt die laufende Instanz stattdessen `onNewIntent()`.
      */
     private fun appIntent(): PendingIntent =
         PendingIntent.getActivity(
             context,
             3,
             Intent(context, MainActivity::class.java)
-                .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP),
+                .setFlags(
+                    Intent.FLAG_ACTIVITY_NEW_TASK or
+                        Intent.FLAG_ACTIVITY_CLEAR_TOP or
+                        Intent.FLAG_ACTIVITY_SINGLE_TOP
+                )
+                .putExtra(MainActivity.EXTRA_EINSTIEG, MainActivity.EINSTIEG_DIMMER_BEDIENUNGSHILFEN),
+            // FLAG_UPDATE_CURRENT: PendingIntents vergleichen sich OHNE Extras - ein aelterer,
+            // noch registrierter PendingIntent unter demselben Request-Code (aus einer Version
+            // vor diesem Extra) wuerde sonst weiterverwendet und traege das Ziel nicht.
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
 

--- a/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/ui/screens/tabs/StatusPermissionCards.kt
+++ b/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/ui/screens/tabs/StatusPermissionCards.kt
@@ -1188,14 +1188,32 @@ internal fun DndPermissionCard() {
 }
 
 /**
+ * Die Seite EINES Bedienungshilfen-Dienstes, ab Android 11.
+ *
+ * ALS TEXT UND NICHT ALS `Settings.`-KONSTANTE, weil es die Konstante im SDK nicht gibt: sie ist
+ * in AOSP `@hide`, und `Settings.ACTION_ACCESSIBILITY_DETAILS_SETTINGS` scheitert beim
+ * Uebersetzen mit „Unresolved reference" (in der CI belegt, 05.09.2026). Dasselbe gilt fuer den
+ * Extra-Schluessel. Das ZIEL gibt es trotzdem — die Einstellungen-App verarbeitet die Aktion seit
+ * Android 11; sie steht nur nicht in `android.jar`. Wer die beiden Zeilen „aufraeumen" und durch
+ * Konstanten ersetzen will, bricht damit den Build.
+ *
+ * Fehlt die Aktion auf einem Geraet, wirft `startActivity` — dafuer gibt es den Rueckfall auf die
+ * Liste, siehe [openAccessibilitySettings].
+ */
+private const val AKTION_BEDIENUNGSHILFEN_DETAILS = "android.settings.ACCESSIBILITY_DETAILS_SETTINGS"
+
+/** Kennung des Dienstes fuer [AKTION_BEDIENUNGSHILFEN_DETAILS], flach geschriebener ComponentName. */
+private const val EXTRA_BEDIENUNGSHILFEN_KOMPONENTE = "android.intent.extra.COMPONENT_NAME"
+
+/**
  * Fuehrt in die Bedienungshilfen — moeglichst auf die Seite GENAU DIESES Dienstes.
  *
  * WARUM ZWEISTUFIG: `ACTION_ACCESSIBILITY_SETTINGS` oeffnet die Liste ALLER Bedienungshilfen;
  * dort steht der Eintrag der App zwischen Systemdiensten und, je nach Hersteller, hinter einer
  * Unterrubrik wie „Heruntergeladene Apps" — der Nutzer kommt aus einer Meldung, die ihm sagt,
- * was zu tun ist, und muss den Schalter dann trotzdem suchen. Ab Android 11 gibt es
- * `ACTION_ACCESSIBILITY_DETAILS_SETTINGS`, das direkt auf die Seite eines benannten Dienstes
- * fuehrt (Kennung als flach geschriebener [ComponentName] im Extra).
+ * was zu tun ist, und muss den Schalter dann trotzdem suchen. Ab Android 11 fuehrt
+ * [AKTION_BEDIENUNGSHILFEN_DETAILS] direkt auf die Seite eines benannten Dienstes (Kennung als
+ * flach geschriebener [ComponentName] im Extra).
  *
  * Die Liste bleibt als Rueckfallebene: das Detail-Ziel ist nicht auf jedem Geraet vorhanden, und
  * eine Bedienungshilfen-Einstellung, die sich gar nicht oeffnet, waere schlechter als eine, in
@@ -1206,8 +1224,8 @@ private fun openAccessibilitySettings(context: android.content.Context) {
         val dienst = ComponentName(context, DimAccessibilityService::class.java).flattenToString()
         try {
             context.startActivity(
-                Intent(Settings.ACTION_ACCESSIBILITY_DETAILS_SETTINGS)
-                    .putExtra(Intent.EXTRA_COMPONENT_NAME, dienst)
+                Intent(AKTION_BEDIENUNGSHILFEN_DETAILS)
+                    .putExtra(EXTRA_BEDIENUNGSHILFEN_KOMPONENTE, dienst)
             )
             return
         } catch (e: Exception) {

--- a/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/ui/screens/tabs/StatusPermissionCards.kt
+++ b/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/ui/screens/tabs/StatusPermissionCards.kt
@@ -2,6 +2,7 @@ package com.github.f1rlefanz.cf_alarmfortimeoffice.ui.screens.tabs
 
 import android.app.AlarmManager
 import android.app.NotificationManager
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.os.Build
@@ -34,6 +35,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -988,14 +990,33 @@ internal fun TimeOfficeHealthCard() {
  * Wie die Nachbarkarten wird der Zustand bei jedem ON_RESUME frisch gelesen — nach der Rueckkehr
  * aus den Bedienungshilfen-Einstellungen springt die Karte so sofort auf gruen. Android startet
  * den Dienst nicht automatisch neu, wenn der Nutzer ihn dort abschaltet.
+ *
+ * @param aktivierungsAnfragen zaehlt die Einstiege aus der Dimmer-Benachrichtigung „Dimmt nicht —
+ *   Bedienungshilfen-Dienst ist aus" (siehe `StatusTabContent`). Jeder Anstieg oeffnet die
+ *   Offenlegung, ohne dass die Karte einen Verbrauch zurueckmelden muesste. Laeuft der Dienst
+ *   inzwischen doch, passiert nichts — die Meldung hat sich dann von selbst erledigt.
  */
 @Composable
-internal fun DimmerAccessibilityCard() {
+internal fun DimmerAccessibilityCard(
+    aktivierungsAnfragen: Int,
+    modifier: Modifier = Modifier
+) {
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
 
     var isActive by remember { mutableStateOf(DimAccessibilityService.isRunning()) }
-    var showDisclosure by remember { mutableStateOf(false) }
+    // rememberSaveable: eine Drehung darf die Offenlegung nicht wegnehmen — sie ist der einzige
+    // Weg zum Aktivieren, und ein erneuter Einstieg aus der Benachrichtigung kommt nach der
+    // Drehung bewusst nicht noch einmal (siehe MainActivity.onCreate).
+    var showDisclosure by rememberSaveable { mutableStateOf(false) }
+
+    // Der Nutzer hat die Benachrichtigung angetippt, um zu aktivieren - dann steht hier die
+    // Pflicht-Offenlegung, und der Knopf dahinter fuehrt direkt auf die Seite dieses Dienstes.
+    LaunchedEffect(aktivierungsAnfragen) {
+        if (aktivierungsAnfragen > 0 && !DimAccessibilityService.isRunning()) {
+            showDisclosure = true
+        }
+    }
 
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
@@ -1027,7 +1048,7 @@ internal fun DimmerAccessibilityCard() {
     }
 
     Card(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(
             containerColor = if (isActive)
                 MaterialTheme.colorScheme.surface
@@ -1166,7 +1187,37 @@ internal fun DndPermissionCard() {
     }
 }
 
+/**
+ * Fuehrt in die Bedienungshilfen — moeglichst auf die Seite GENAU DIESES Dienstes.
+ *
+ * WARUM ZWEISTUFIG: `ACTION_ACCESSIBILITY_SETTINGS` oeffnet die Liste ALLER Bedienungshilfen;
+ * dort steht der Eintrag der App zwischen Systemdiensten und, je nach Hersteller, hinter einer
+ * Unterrubrik wie „Heruntergeladene Apps" — der Nutzer kommt aus einer Meldung, die ihm sagt,
+ * was zu tun ist, und muss den Schalter dann trotzdem suchen. Ab Android 11 gibt es
+ * `ACTION_ACCESSIBILITY_DETAILS_SETTINGS`, das direkt auf die Seite eines benannten Dienstes
+ * fuehrt (Kennung als flach geschriebener [ComponentName] im Extra).
+ *
+ * Die Liste bleibt als Rueckfallebene: das Detail-Ziel ist nicht auf jedem Geraet vorhanden, und
+ * eine Bedienungshilfen-Einstellung, die sich gar nicht oeffnet, waere schlechter als eine, in
+ * der man scrollen muss.
+ */
 private fun openAccessibilitySettings(context: android.content.Context) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        val dienst = ComponentName(context, DimAccessibilityService::class.java).flattenToString()
+        try {
+            context.startActivity(
+                Intent(Settings.ACTION_ACCESSIBILITY_DETAILS_SETTINGS)
+                    .putExtra(Intent.EXTRA_COMPONENT_NAME, dienst)
+            )
+            return
+        } catch (e: Exception) {
+            Logger.w(
+                LogTags.UI,
+                "Direkte Bedienungshilfen-Seite nicht erreichbar (${e.message}) - weiter ueber die Liste"
+            )
+        }
+    }
+
     try {
         context.startActivity(Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS))
     } catch (e: Exception) {

--- a/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/ui/screens/tabs/StatusTabContent.kt
+++ b/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/ui/screens/tabs/StatusTabContent.kt
@@ -38,16 +38,22 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.github.f1rlefanz.cf_alarmfortimeoffice.alarm.FeedNeueinlesenStand
+import com.github.f1rlefanz.cf_alarmfortimeoffice.dimmer.DimBedienungshilfenWunsch
 import com.github.f1rlefanz.cf_alarmfortimeoffice.model.AuthState
 import com.github.f1rlefanz.cf_alarmfortimeoffice.service.AlarmMaintenanceService
 import com.github.f1rlefanz.cf_alarmfortimeoffice.ui.components.CompactButton
@@ -58,6 +64,7 @@ import com.github.f1rlefanz.cf_alarmfortimeoffice.viewmodel.AuthViewModel
 import com.github.f1rlefanz.cf_alarmfortimeoffice.viewmodel.CalendarUiState
 import com.github.f1rlefanz.cf_alarmfortimeoffice.viewmodel.CalendarViewModel
 import com.github.f1rlefanz.cf_alarmfortimeoffice.viewmodel.ShiftUiState
+import kotlinx.coroutines.flow.first
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -77,14 +84,48 @@ fun StatusTabContent(
 ) {
     val context = LocalContext.current
 
+    // EINSTIEG AUS DER DIMMER-BENACHRICHTIGUNG ("Dimmt nicht - Bedienungshilfen-Dienst ist aus").
+    // Sie fuehrt bewusst hierher statt direkt in die Android-Einstellungen (Play-Pflicht-
+    // Offenlegung, siehe DimCorrectionNotifier.appIntent) - dann muss dieser Bildschirm den
+    // Nutzer aber auch bis zur richtigen Karte bringen: sie steht unterhalb von sechs anderen.
+    val scrollState = rememberScrollState()
+    // Versatz der Bedienungshilfen-Karte INNERHALB des scrollbaren Inhalts, in Pixeln.
+    // -1 = noch nicht vermessen (erste Komposition).
+    var dimmerKarteVersatz by remember { mutableIntStateOf(-1) }
+    // Zaehler statt Boolean: jede neue Anfrage oeffnet die Offenlegung erneut, ohne dass die
+    // Karte ein Zuruecksetzen zurueckmelden muesste - ein solcher Rueckkanal wuerde als
+    // LaunchedEffect-Schluessel den noch laufenden Bildlauf unten mittendrin abbrechen.
+    var kartenAnfragen by remember { mutableIntStateOf(0) }
+    var spalteObenImFenster by remember { mutableFloatStateOf(0f) }
+    // BEWUSST HIER gelesen und nicht erst im Rueckruf unten: so haengt die Komposition daran.
+    // Steht der Wert beim ersten Vermessen der Karte noch auf 0, korrigiert ihn die naechste
+    // Zusammensetzung von selbst - ein Lesen erst im Rueckruf wuerde nichts anstossen, und ein
+    // zu grosses Bildlaufziel bliebe stehen.
+    val spalteOben = spalteObenImFenster
+
+    LaunchedEffect(Unit) {
+        // Schluessel `Unit`, nicht der Wunsch selbst: `verbrauchen()` setzt ihn sofort zurueck,
+        // und ein daran haengender Effekt wuerde sich selbst abbrechen - mitten im Bildlauf.
+        DimBedienungshilfenWunsch.offen.collect { offen ->
+            if (!offen) return@collect
+            DimBedienungshilfenWunsch.verbrauchen()
+            kartenAnfragen++
+            // Erst rollen, wenn die Karte vermessen ist - beim Einstieg direkt aus der
+            // Benachrichtigung laeuft dieser Effekt vor dem ersten Layout-Durchgang.
+            val ziel = snapshotFlow { dimmerKarteVersatz }.first { it >= 0 }
+            scrollState.animateScrollTo(ziel)
+        }
+    }
+
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .verticalScroll(rememberScrollState())
+            .onGloballyPositioned { spalteObenImFenster = it.positionInRoot().y }
+            .verticalScroll(scrollState)
             .padding(SpacingConstants.PADDING_SCREEN_HORIZONTAL),
         verticalArrangement = Arrangement.spacedBy(SpacingConstants.SPACING_LARGE)
     ) {
-        
+
         // GANZ OBEN und nicht bei der Kalender-Karte darunter: Wenn diese Karte erscheint,
         // klingeln Wecker eines Dienstplans, den der Nutzer entfernt hat - das schlaegt jeden
         // anderen Status auf diesem Bildschirm.
@@ -238,7 +279,17 @@ fun StatusTabContent(
         // Schicht-Dimmer: laeuft der Bedienungshilfen-Dienst? Nur dann kann das Dimm-Overlay
         // ueberhaupt erscheinen. Der Status stand frueher im Dimmer-Tab; hier neben den anderen
         // OS-Berechtigungen ist er dauerhaft ablesbar und der Dienst von einer Stelle aus aktivierbar.
-        DimmerAccessibilityCard()
+        DimmerAccessibilityCard(
+            // positionInRoot beider Seiten, weil der Bildlauf die Karte im Fenster verschiebt:
+            // die Differenz plus der aktuelle Stand ergibt den Versatz im INHALT, und nur der
+            // ist ein brauchbares Bildlaufziel.
+            modifier = Modifier.onGloballyPositioned { koordinaten ->
+                dimmerKarteVersatz =
+                    (koordinaten.positionInRoot().y - spalteOben + scrollState.value)
+                        .toInt().coerceAtLeast(0)
+            },
+            aktivierungsAnfragen = kartenAnfragen
+        )
 
         // DND-Steuerung: Freigabe-Status fuer ACCESS_NOTIFICATION_POLICY, analog zur
         // Bedienungshilfen-Karte des Dimmers.
@@ -647,7 +698,6 @@ private fun StatusCard(
                     details,
                     style = MaterialTheme.typography.bodyMedium
                 )
-
                 if (!isOk && actionLabel != null && onAction != null) {
                     Spacer(Modifier.height(SpacingConstants.SPACING_SMALL))
                     SettingsLinkButton(onClick = onAction, text = actionLabel, enabled = actionEnabled)

--- a/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/ui/screens/tabs/StatusTabContent.kt
+++ b/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/ui/screens/tabs/StatusTabContent.kt
@@ -698,6 +698,7 @@ private fun StatusCard(
                     details,
                     style = MaterialTheme.typography.bodyMedium
                 )
+
                 if (!isOk && actionLabel != null && onAction != null) {
                     Spacer(Modifier.height(SpacingConstants.SPACING_SMALL))
                     SettingsLinkButton(onClick = onAction, text = actionLabel, enabled = actionEnabled)

--- a/app/src/test/java/com/github/f1rlefanz/cf_alarmfortimeoffice/dimmer/DimBedienungshilfenWunschTest.kt
+++ b/app/src/test/java/com/github/f1rlefanz/cf_alarmfortimeoffice/dimmer/DimBedienungshilfenWunschTest.kt
@@ -110,7 +110,7 @@ class DimBedienungshilfenWunschTest {
         assertFalse(
             "Die Benachrichtigung fuehrt direkt in die Bedienungshilfen-Einstellungen - damit " +
                 "faellt die Play-Pflicht-Offenlegung aus, die nur die Karte zeigt",
-            notifier.contains("ACTION_ACCESSIBILITY")
+            notifier.contains("ACCESSIBILITY")
         )
     }
 
@@ -201,14 +201,17 @@ class DimBedienungshilfenWunschTest {
     fun `der Knopf fuehrt auf die Seite DIESES Dienstes - mit Rueckfall auf die Liste`() {
         val karten = ohneKommentare("ui/screens/tabs/StatusPermissionCards.kt")
 
+        // Aktion und Extra stehen als TEXT im Code, nicht als Settings-/Intent-Konstante: die
+        // gibt es im SDK nicht (in AOSP @hide, der Uebersetzer meldet "Unresolved reference" -
+        // in der CI belegt). Deshalb prueft der Test die Zeichenketten selbst.
         assertTrue(
-            "Ohne ACTION_ACCESSIBILITY_DETAILS_SETTINGS landet der Nutzer in der Liste ALLER " +
+            "Ohne die Aktion ACCESSIBILITY_DETAILS_SETTINGS landet der Nutzer in der Liste ALLER " +
                 "Bedienungshilfen und sucht den Eintrag der App selbst",
-            karten.contains("Settings.ACTION_ACCESSIBILITY_DETAILS_SETTINGS")
+            karten.contains("\"android.settings.ACCESSIBILITY_DETAILS_SETTINGS\"")
         )
         assertTrue(
             "Die Detailseite braucht die Kennung des Dienstes, sonst zeigt sie nichts an",
-            karten.contains("Intent.EXTRA_COMPONENT_NAME") &&
+            karten.contains("\"android.intent.extra.COMPONENT_NAME\"") &&
                 karten.contains("ComponentName(context, DimAccessibilityService::class.java)")
         )
         assertTrue(

--- a/app/src/test/java/com/github/f1rlefanz/cf_alarmfortimeoffice/dimmer/DimBedienungshilfenWunschTest.kt
+++ b/app/src/test/java/com/github/f1rlefanz/cf_alarmfortimeoffice/dimmer/DimBedienungshilfenWunschTest.kt
@@ -1,0 +1,220 @@
+package com.github.f1rlefanz.cf_alarmfortimeoffice.dimmer
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Der WEG von der Meldung „Dimmt nicht — Bedienungshilfen-Dienst ist aus" bis zu dem Schalter,
+ * der sie aufloest.
+ *
+ * HERGANG (04.09.2026): Die Meldung sagte „Zum Aktivieren tippen", und der Tipp oeffnete die App
+ * — irgendwo, auf dem zuletzt benutzten Tab. Die Karte, die den Dienst aktivieren laesst, steht
+ * im Status-Tab unterhalb von sechs anderen; wer der Aufforderung folgte, landete also in einer
+ * Liste und musste selbst suchen. Am Ende derselben Kette wartete der zweite Bruch: der Knopf
+ * der Karte oeffnete die Liste ALLER Bedienungshilfen, in der der Eintrag der App zwischen
+ * Systemdiensten steht. Eine Meldung mit einem Ausweg, den man suchen muss, ist nur die halbe
+ * Meldung.
+ *
+ * WARUM DER SPRUNG NICHT DIREKT IN DIE EINSTELLUNGEN GEHT: Vor dem Aktivieren eines
+ * Bedienungshilfen-Dienstes steht die Play-Pflicht-Offenlegung. Sie zeigt die Karte — deshalb
+ * fuehrt die Benachrichtigung zur KARTE und nicht an ihr vorbei. Genau diese Reihenfolge sichern
+ * die Tests unten ab; sie ist der Grund, warum der Weg zwei Stationen hat statt einer.
+ *
+ * Composables und Android-Intents lassen sich ohne Framework nicht ausfuehren. Pruefbar ist
+ * deshalb der Quelltext der Kette (dasselbe Vorgehen wie in `AbgleichUndZeitanzeigeTest`) — plus
+ * das eine Glied, das bewusst als reines Kotlin-Objekt daneben liegt.
+ */
+class DimBedienungshilfenWunschTest {
+
+    private fun quelltext(pfad: String): String =
+        File("src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/$pfad").readText()
+
+    /**
+     * Quelltext ohne Kommentare. Die Begruendungen in diesen Dateien nennen die geforderten
+     * Aufrufe absichtlich beim Namen — ohne diesen Filter waere jeder Test schon dadurch gruen,
+     * dass jemand ordentlich dokumentiert hat.
+     */
+    private fun ohneKommentare(pfad: String): String =
+        quelltext(pfad).lines()
+            .filterNot { it.trimStart().startsWith("//") }
+            .filterNot { it.trimStart().startsWith("*") }
+            .filterNot { it.trimStart().startsWith("/*") }
+            .joinToString("\n")
+
+    @After
+    fun raeumeAuf() {
+        // Prozessweites Objekt: ein stehengebliebener Wunsch wuerde in den naechsten Test lecken.
+        DimBedienungshilfenWunsch.verbrauchen()
+    }
+
+    // ---------------------------------------------------------------- das Signal selbst
+
+    @Test
+    fun `ohne Einstieg aus der Benachrichtigung steht kein Wunsch an`() {
+        assertFalse(
+            "Ein Wunsch, den niemand gestellt hat, wuerde die Offenlegung beim blossen Oeffnen des Status-Tabs aufpoppen lassen",
+            DimBedienungshilfenWunsch.offen.value
+        )
+    }
+
+    @Test
+    fun `ein gestellter Wunsch steht an, bis er verbraucht wird`() {
+        DimBedienungshilfenWunsch.stellen()
+        assertTrue(DimBedienungshilfenWunsch.offen.value)
+
+        // Zweimal tippen darf nichts kaputtmachen - der Wunsch bleibt EIN Wunsch.
+        DimBedienungshilfenWunsch.stellen()
+        assertTrue(DimBedienungshilfenWunsch.offen.value)
+
+        DimBedienungshilfenWunsch.verbrauchen()
+        assertFalse(
+            "Nach dem Verbrauchen darf derselbe Wunsch nicht ein zweites Mal wirken",
+            DimBedienungshilfenWunsch.offen.value
+        )
+    }
+
+    // ---------------------------------------------------------------- Station 1: die Meldung
+
+    @Test
+    fun `die Benachrichtigung nennt ihr Ziel im Intent`() {
+        val notifier = ohneKommentare("dimmer/DimCorrectionNotifier.kt")
+
+        assertTrue(
+            "Ohne das Extra landet der Tipp auf dem zuletzt benutzten Tab - die Karte, um die es " +
+                "geht, bleibt ungesehen",
+            notifier.contains("MainActivity.EXTRA_EINSTIEG") &&
+                notifier.contains("MainActivity.EINSTIEG_DIMMER_BEDIENUNGSHILFEN")
+        )
+    }
+
+    @Test
+    fun `der Tipp wirft eine laufende App nicht weg`() {
+        val notifier = ohneKommentare("dimmer/DimCorrectionNotifier.kt")
+
+        // FLAG_ACTIVITY_CLEAR_TOP allein legt MainActivity (Start-Modus `standard`) neu an,
+        // statt ihr onNewIntent zu geben - der Nutzer verlaere seinen Stand.
+        assertTrue(
+            "FLAG_ACTIVITY_SINGLE_TOP fehlt - CLEAR_TOP legt MainActivity dann neu an",
+            notifier.contains("FLAG_ACTIVITY_SINGLE_TOP")
+        )
+    }
+
+    @Test
+    fun `die Benachrichtigung springt NICHT an der Offenlegung vorbei`() {
+        val notifier = ohneKommentare("dimmer/DimCorrectionNotifier.kt")
+
+        assertFalse(
+            "Die Benachrichtigung fuehrt direkt in die Bedienungshilfen-Einstellungen - damit " +
+                "faellt die Play-Pflicht-Offenlegung aus, die nur die Karte zeigt",
+            notifier.contains("ACTION_ACCESSIBILITY")
+        )
+    }
+
+    // ---------------------------------------------------------------- Station 2: der Einstieg
+
+    @Test
+    fun `MainActivity setzt den Einstieg in Navigation um`() {
+        val activity = ohneKommentare("MainActivity.kt")
+
+        assertTrue(
+            "MainActivity wertet das Einstiegs-Extra nicht aus - die Benachrichtigung fuehrt " +
+                "dann wieder irgendwohin",
+            activity.contains("EINSTIEG_DIMMER_BEDIENUNGSHILFEN ->")
+        )
+        assertTrue(
+            "Der Wunsch wird nicht gestellt - die Karte zeigt ihre Offenlegung dann nicht",
+            activity.contains("DimBedienungshilfenWunsch.stellen()")
+        )
+        assertTrue(
+            "Ohne den Tab-Wechsel bleibt der Nutzer, wo er war - die Karte steht im Status-Tab",
+            activity.contains("navigateToMainWithTab(MainTab.STATUS)")
+        )
+    }
+
+    @Test
+    fun `eine laufende App bekommt das neue Ziel auch wirklich zu sehen`() {
+        val activity = ohneKommentare("MainActivity.kt")
+
+        // Ohne setIntent() liefert getIntent() weiter den Start-Intent; dieselbe Falle wie am
+        // Weckbildschirm (AlarmFullScreenActivity.onNewIntent).
+        assertTrue(
+            "onNewIntent fehlt oder ruft setIntent nicht - der Tipp auf die Benachrichtigung " +
+                "bliebe bei laufender App wirkungslos",
+            Regex("""override fun onNewIntent\(intent: Intent\)[\s\S]{0,200}?setIntent\(intent\)""")
+                .containsMatchIn(activity)
+        )
+    }
+
+    // ---------------------------------------------------------------- Station 3: die Karte
+
+    @Test
+    fun `der Status-Tab loest den Wunsch ein statt ihn nur zu lesen`() {
+        val statusTab = ohneKommentare("ui/screens/tabs/StatusTabContent.kt")
+
+        assertTrue(
+            "Der Wunsch wird nicht verbraucht - er wirkte beim naechsten Oeffnen des Status-Tabs erneut",
+            statusTab.contains("DimBedienungshilfenWunsch.verbrauchen()")
+        )
+        assertTrue(
+            "Ohne Bildlauf steht die Karte weiter unterhalb des sichtbaren Bereichs - genau die " +
+                "Suche, die dieser Weg abschaffen soll",
+            statusTab.contains("animateScrollTo")
+        )
+        assertTrue(
+            "Die Karte erfaehrt nichts von der Anfrage und zeigt die Offenlegung nicht",
+            statusTab.contains("aktivierungsAnfragen = kartenAnfragen")
+        )
+    }
+
+    @Test
+    fun `die Karte zeigt auf Anfrage die Offenlegung und nicht die Einstellung`() {
+        val karten = ohneKommentare("ui/screens/tabs/StatusPermissionCards.kt")
+
+        assertTrue(
+            "Die Anfrage aus der Benachrichtigung oeffnet die Offenlegung nicht",
+            Regex("""LaunchedEffect\(aktivierungsAnfragen\)[\s\S]{0,300}?showDisclosure = true""")
+                .containsMatchIn(karten)
+        )
+        // Die eigentliche Zusicherung: es gibt genau EINEN Weg in die Einstellungen, und er
+        // beginnt hinter der Offenlegung. Waere daneben ein zweiter (etwa aus dem Effekt oben),
+        // koennte die Anfrage aus der Benachrichtigung an ihr vorbeilaufen.
+        assertEquals(
+            "Es gibt mehr als einen Weg in die Bedienungshilfen-Einstellungen - einer davon " +
+                "kommt an der Play-Pflicht-Offenlegung vorbei",
+            1,
+            Regex("""openAccessibilitySettings\(context\)""").findAll(karten).count()
+        )
+        assertTrue(
+            "Der Sprung in die Einstellungen haengt nicht mehr am Bestaetigen der Offenlegung",
+            Regex("""showDisclosure = false\s+openAccessibilitySettings\(context\)""")
+                .containsMatchIn(karten)
+        )
+    }
+
+    // ---------------------------------------------------------------- Station 4: die Einstellung
+
+    @Test
+    fun `der Knopf fuehrt auf die Seite DIESES Dienstes - mit Rueckfall auf die Liste`() {
+        val karten = ohneKommentare("ui/screens/tabs/StatusPermissionCards.kt")
+
+        assertTrue(
+            "Ohne ACTION_ACCESSIBILITY_DETAILS_SETTINGS landet der Nutzer in der Liste ALLER " +
+                "Bedienungshilfen und sucht den Eintrag der App selbst",
+            karten.contains("Settings.ACTION_ACCESSIBILITY_DETAILS_SETTINGS")
+        )
+        assertTrue(
+            "Die Detailseite braucht die Kennung des Dienstes, sonst zeigt sie nichts an",
+            karten.contains("Intent.EXTRA_COMPONENT_NAME") &&
+                karten.contains("ComponentName(context, DimAccessibilityService::class.java)")
+        )
+        assertTrue(
+            "Der Rueckfall auf die Liste fehlt - das Detail-Ziel gibt es nicht auf jedem Geraet, " +
+                "und eine Einstellung, die sich gar nicht oeffnet, ist schlechter als eine zum Scrollen",
+            karten.contains("Settings.ACTION_ACCESSIBILITY_SETTINGS")
+        )
+    }
+}


### PR DESCRIPTION
## Worum es geht

Die Meldung „Dimmt nicht — Bedienungshilfen-Dienst ist aus" sagte, WAS zu tun ist, aber nicht, WO:

- Der Tipp öffnete die App auf dem zuletzt benutzten Tab. Die Karte, die den Dienst aktivieren lässt, steht im Status-Tab **unterhalb von sechs anderen**.
- Am Ende derselben Kette öffnete ihr Knopf die Liste **aller** Bedienungshilfen, in der der Eintrag der App zwischen Systemdiensten steht.

Beide Enden waren formal richtig und praktisch eine Schnitzeljagd.

## Warum der Weg zwei Stationen hat

Direkt aus der Benachrichtigung in die Android-Einstellungen zu springen bleibt ausgeschlossen — davor gehört die Play-Pflicht-Offenlegung, und die zeigt nur die Karte. Deshalb:

1. **Die Benachrichtigung** trägt ein Intent-Extra (`MainActivity.EXTRA_EINSTIEG`), das sagt, weshalb geöffnet wurde.
2. **MainActivity** stellt den Wunsch (`DimBedienungshilfenWunsch`) und wechselt auf den Status-Tab.
3. **Der Status-Tab** verbraucht den Wunsch, rollt die Bedienungshilfen-Karte ins Bild und reicht die Anfrage an sie weiter.
4. **Die Karte** zeigt die Offenlegung; erst deren Knopf springt — ab Android 11 über die Aktion `ACCESSIBILITY_DETAILS_SETTINGS` direkt auf die Seite DIESES Dienstes, mit Rückfall auf die Liste (das Detail-Ziel gibt es nicht auf jedem Gerät).

## Konstruktionsdetails, die nicht offensichtlich sind

- `FLAG_ACTIVITY_SINGLE_TOP` neben `CLEAR_TOP`: ohne das Flag legt Android die laufende MainActivity (Start-Modus `standard`) neu an, statt ihr `onNewIntent` zu geben — der Nutzer verlöre seinen Stand.
- `onNewIntent` ruft `setIntent()`, sonst liefert `getIntent()` weiter den Start-Intent (dieselbe Falle wie am Weckbildschirm).
- Die Auswertung in `onCreate` steht hinter `savedInstanceState == null`, sonst schickt jede Drehung den Nutzer erneut auf den Status-Tab.
- Das Signal an die Karte ist ein **Zähler**, kein Boolean: ein Rückkanal „verbraucht" wäre als `LaunchedEffect`-Schlüssel gerade der Wert, der den noch laufenden Bildlauf mittendrin abbräche.
- Das Bildlaufziel kommt aus `positionInRoot()` von Karte und Spalte plus dem aktuellen Stand — der reine Abstand im Fenster verschiebt sich beim Rollen mit.
- **Aktion und Extra-Schlüssel stehen als Zeichenketten im Code, nicht als `Settings.`/`Intent.`-Konstante.** Die gibt es im SDK nicht — sie sind in AOSP `@hide`, und `Settings.ACTION_ACCESSIBILITY_DETAILS_SETTINGS` scheitert beim Übersetzen mit „Unresolved reference" (in der CI dieses PRs belegt, erster Lauf rot). Das Ziel existiert trotzdem; es steht nur nicht in `android.jar`. Wer die beiden Zeilen zu Konstanten „aufräumt", bricht den Build erneut — deshalb steht der Hergang im KDoc daneben.

## Tests

Neu: `DimBedienungshilfenWunschTest` — das Einmal-Signal als reiner JVM-Test, dazu vier Stationen als Quelltext-Zusicherungen (Extra + SINGLE_TOP + kein Direktsprung an der Offenlegung vorbei; `onNewIntent` mit `setIntent`; Verbrauch, Bildlauf und Weiterreichen im Status-Tab; Detailseite mit Rückfall auf die Liste). Muster und Kommentarfilter wie in `AbgleichUndZeitanzeigeTest`.

## Stand der Prüfung

`main` ist eingemergt (1.39.6/132), damit läuft die CI über den Stand, der beim Merge wirklich entsteht — nicht über einen älteren Basisstand. Kein Konflikt, die fünf geänderten Dateien dieses PRs bleiben davon unberührt.

Zusätzlich sind die Schleusen-Prüfungen gelaufen, die kein Gradle brauchen: Code-Invarianten (6/6), Skill-Frontmatter (10/10), Doku-Budget, Aufräum-Reste, Changelog-Seite gegen Markdown — alle grün.

**Was hier NICHT geprüft werden konnte:** die Sitzung lief in der Cloud, ohne Android-SDK und ohne adb (`dl.google.com` und `api.foojay.io` sind dort gesperrt, Gradle startet nicht). Am Gerät fehlen deshalb zwei Belege — **nachgehalten als #66**, mit dem read-only `am start`-Kommando fürs Fairphone und dem Emulator-Ablauf:

1. Dass die Detailseite wirklich mit dem Eintrag der App öffnet — sonst greift still der Rückfall, und der ist die Liste von vorher.
2. Dass der Bildlauf die Karte trifft, wenn die App aus der Benachrichtigung **kalt** startet — dort läuft der Effekt vor dem ersten Layout-Durchgang und wartet auf die Vermessung.

Die Navigationsfrage dahinter ist schon ohne Gerät geklärt: der in `onCreate` gesetzte Tab überlebt die Anmelde- und Onboarding-Gates, weil `handleAuthenticationSuccess()` nur umleitet, wenn der Zustand ohnehin `MainContent` ist, und sonst niemand `MainContent(MainTab.HOME)` setzt. Offen ist am Kaltstart die Layout-Zeitfrage.

## Doku

Kurzregel in `cfalarm-dimmer-und-dnd/SKILL.md`, Hergang mit den vier Fallen und der offenen Geräteprüfung in `reference/dimmer.md`.

**Kein Versionsbump und kein Changelog-Eintrag** — beides gehört hinter die Geräteprüfung aus #66, weil ein Bump auf `main` in diesem Projekt die Auslieferung an echte Tester auslöst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QbQuZAN7nr5k8b4XGzMbca