### PR TITLE
feat(wecker): sanfter Lautstaerke-Anstieg, einstellbar

### DIFF
--- a/.claude/skills/cfalarm-wecker-und-boot/SKILL.md
+++ b/.claude/skills/cfalarm-wecker-und-boot/SKILL.md
@@ -149,6 +149,40 @@ Saetze: `reference/vorwecken.md`.
   Der Zaehler faellt bei jedem sauberen Wecker auf 0 — das ist jetzt gefahrlos und war es
   vorher nicht.
 
+## Sanfter Weckton-Anstieg — Kurzregeln
+
+Optional, ab Werk AUS. Schalter, Anlaufzeit und Startpegel im Wecker-Tab; Rechenkern
+`alarm/LautstaerkeAnstieg.kt` (rein, unter Test), Werte in `AlarmPrefs`.
+
+- **Der Anstieg fasst die System-Lautstaerke NICHT an.** Er skaliert ausschliesslich den eigenen
+  Player per `MediaPlayer.setVolume()`. `AudioManager.setStreamVolume(STREAM_ALARM, ...)` ist
+  verboten: stirbt der Prozess mitten im Anstieg — nachts, ohne Zeugen — bliebe die
+  Alarm-Lautstaerke des GERAETS dauerhaft auf dem Anfangswert stehen, und das naechste Wecken
+  waere leise, ohne dass irgendetwas darauf hinweist.
+- **Ton und Melodie bleiben Sache von Android.** Es gibt bewusst KEINE App-eigene Ton- oder
+  Lautstaerkeauswahl daneben — sie waere eine zweite Wahrheit und eine Stelle, an der die App
+  leiser sein kann, als der Nutzer glaubt. Der Anstieg ist die einzige Ausnahme, weil Android
+  genau ihn nicht anbietet.
+- **Jede Unklarheit degradiert auf VOLLE Lautstaerke**, nie auf einen leisen Wecker: unlesbarer
+  DataStore, fehlende Intent-Extras, unbrauchbare Eingaben. Auch Direct Boot faellt darunter —
+  der Receiver liest den CE-Storage dort nicht, der Anstieg entfaellt also.
+- **Der Anstieg braucht einen BACKSTOP, der nicht an der Schrittkette haengt.** Ein zweiter,
+  unabhaengiger `postDelayed` stellt am Ende bedingungslos auf voll. Ohne ihn friert ein
+  abgerissener Schritt den Wecker auf dem Anfangspegel ein — das ist ein verschlafener Dienst.
+- **Jeder Anstiegs-Callback prueft `playerGeneration`**, sonst dreht ein Anstieg des VORIGEN
+  Players den neuen leiser (stop -> snooze -> start).
+- **Der Anstieg hat einen EIGENEN Handler**, nicht den `vorweckHandler`: beide raeumen mit
+  `removeCallbacksAndMessages(null)` auf, und der ausstehende Vordergrund-Start darf dabei nicht
+  mitgeloescht werden.
+- **Der Startpegel darf nie 0 sein** (`LautstaerkeAnstieg.MIN_STARTPEGEL`): `0` hoch irgendwas
+  ist 0 — der Wecker bliebe bis zum letzten Schritt stumm und wuerde dann schlagartig laut.
+- **Die Kurve ist geometrisch, nicht linear.** `setVolume()` nimmt eine Amplitude, das Ohr hoert
+  logarithmisch; linear klingt, als sei der Anstieg nach einem Viertel der Zeit vorbei.
+- **Die Obergrenze der Anlaufzeit (120 s) ist Absicht.** Ein laengerer Anlauf ist kein sanfterer
+  Wecker, sondern ein spaeterer.
+- **Die Vibration ist NICHT Teil des Anstiegs** — sie startet weiterhin sofort in voller Staerke.
+  Bewusst offen gelassen; wer das aendert, aendert die Weckwirkung selbst.
+
 ## Master-Pause — Kurzregeln
 
 - **Eigenständig neben `autoAlarmEnabled`** — `pause()`/`resume()` rühren den Flag NICHT an, sondern

--- a/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/AlarmReceiver.kt
+++ b/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/AlarmReceiver.kt
@@ -11,6 +11,7 @@ import android.os.Build
 import android.os.PowerManager
 import androidx.core.app.NotificationCompat
 import com.github.f1rlefanz.cf_alarmfortimeoffice.alarm.AlarmPrefs
+import com.github.f1rlefanz.cf_alarmfortimeoffice.alarm.WecktonAnstieg
 import com.github.f1rlefanz.cf_alarmfortimeoffice.hue.usecase.interfaces.IHueRuleUseCase
 import com.github.f1rlefanz.cf_alarmfortimeoffice.service.AlarmSoundService
 import com.github.f1rlefanz.cf_alarmfortimeoffice.model.AlarmInfo
@@ -599,10 +600,12 @@ class AlarmReceiver : BroadcastReceiver() {
      * @param alarmId Unique alarm identifier
      *
      * SUSPEND: liest [alarmPrefs] EINMAL hier - der einzige Ort, der die konfigurierte
-     * Schlummer-Dauer aus dem DataStore holt. Beide Snooze-Ausloeser (Vollbild-Button,
-     * Notification-Button) bleiben synchron und lesen den Wert stattdessen aus dem Intent-Extra
-     * [AlarmSoundService.EXTRA_SNOOZE_MINUTES], das hier gesetzt wird. Der einzige Aufrufer laeuft
-     * bereits in receiverScope.launch, also ist der suspend-Read hier sicher.
+     * Schlummer-Dauer UND den Weckton-Anstieg aus dem DataStore holt. Beide Snooze-Ausloeser
+     * (Vollbild-Button, Notification-Button) bleiben synchron und lesen den Wert stattdessen aus
+     * dem Intent-Extra [AlarmSoundService.EXTRA_SNOOZE_MINUTES], das hier gesetzt wird; fuer den
+     * Anstieg gilt dasselbe ueber [AlarmSoundService.EXTRA_ANSTIEG_AKTIV] und seine beiden
+     * Nachbarn. Der einzige Aufrufer laeuft bereits in receiverScope.launch, also ist der
+     * suspend-Read hier sicher.
      *
      * DIRECT BOOT: [alarmPrefs] liegt im @MainDataStore (CE-Storage) und ist vor der ersten
      * Entsperrung NICHT lesbar - genau wie der Skip- und Silent-Check weiter oben in onReceive().
@@ -611,6 +614,10 @@ class AlarmReceiver : BroadcastReceiver() {
      * true - sonst waere ein CE-Storage-Read hier fatal statt bloss uebersprungen: der try/catch
      * darunter haette eine Exception (oder ein Haengen) abgefangen, ohne dass startForegroundService()
      * je erreicht wird - der Wecker bliebe nach einem Reboot vor der ersten Entsperrung stumm.
+     *
+     * Fuer den Anstieg ist das Ueberspringen zusaetzlich die inhaltlich richtige Entscheidung: er
+     * entfaellt dann, der Wecker startet sofort in voller Lautstaerke. Nach einem Neustart ohne
+     * Entsperrung ist ein leiser Anlauf das Letzte, was jemand gebrauchen kann.
      *
      * @return true, wenn der Vordergrunddienst wirklich gestartet wurde; false, wenn nur der
      *   Notausgang greift (siehe [starteWeckerMitNotausgang]).
@@ -640,12 +647,32 @@ class AlarmReceiver : BroadcastReceiver() {
             AlarmPrefs.DEFAULT_SNOOZE_MINUTES
         }
 
+        // Eigenes try/catch aus demselben Grund wie oben: ein Lesefehler kostet den Anstieg,
+        // nicht den Wecker. Degradiert wird auf WecktonAnstieg.AUS - volle Lautstaerke.
+        val anstieg = if (userUnlocked) {
+            try {
+                alarmPrefs.wecktonAnstiegNow()
+            } catch (e: Exception) {
+                Logger.w(
+                    LogTags.ALARM_RECEIVER,
+                    "⚠️ Weckton-Anstieg nicht lesbar - Wecker startet sofort in voller Lautstaerke",
+                    e
+                )
+                WecktonAnstieg.AUS
+            }
+        } else {
+            WecktonAnstieg.AUS
+        }
+
         val serviceIntent = Intent(context, AlarmSoundService::class.java).apply {
             action = AlarmSoundService.ACTION_START_ALARM
             putExtra(AlarmSoundService.EXTRA_SHIFT_NAME, shiftName)
             putExtra(AlarmSoundService.EXTRA_SHIFT_START_TIME, shiftStartTime)
             putExtra(AlarmSoundService.EXTRA_ALARM_ID, alarmId)
             putExtra(AlarmSoundService.EXTRA_SNOOZE_MINUTES, snoozeMinutes)
+            putExtra(AlarmSoundService.EXTRA_ANSTIEG_AKTIV, anstieg.aktiv)
+            putExtra(AlarmSoundService.EXTRA_ANSTIEG_SEKUNDEN, anstieg.sekunden)
+            putExtra(AlarmSoundService.EXTRA_ANSTIEG_START_PROZENT, anstieg.startProzent)
         }
 
         val gestartet = starteWeckerMitNotausgang(

--- a/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/alarm/AlarmPrefs.kt
+++ b/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/alarm/AlarmPrefs.kt
@@ -2,6 +2,7 @@ package com.github.f1rlefanz.cf_alarmfortimeoffice.alarm
 
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import com.github.f1rlefanz.cf_alarmfortimeoffice.di.qualifiers.MainDataStore
@@ -15,7 +16,8 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Einstellungen der Schlummer-Dauer (im bestehenden [MainDataStore]).
+ * Einstellungen der Schlummer-Dauer und des sanften Weckton-Anstiegs (im bestehenden
+ * [MainDataStore]).
  *
  * Uebernimmt die frühere Rolle von `AlarmManagerService.SNOOZE_MINUTES` als EINE Quelle fuer
  * Vollbild-Button UND Notification-Button - aber NICHT indem beide Ausloeser diesen DataStore
@@ -52,6 +54,51 @@ class AlarmPrefs @Inject constructor(
          */
         const val MIN_SNOOZE_MINUTES = 1
         const val MAX_SNOOZE_MINUTES = 120
+
+        // ---- Sanfter Weckton-Anstieg -------------------------------------------------------
+        //
+        // WARUM ES DIESE EINSTELLUNGEN GIBT: Ton und Lautstaerke des Weckers kommen vollstaendig
+        // aus den Android-Einstellungen (Standard-Alarmton, Alarm-Regler) - bewusst, denn eine
+        // eigene Auswahl daneben waere eine zweite Wahrheit ohne Gegenwert. Das EINE, was Android
+        // dort nicht anbietet, ist ein sanfter Anstieg. Genau der wird hier konfiguriert, und
+        // sonst nichts: der Anstieg SKALIERT die eingestellte Lautstaerke, er ersetzt sie nicht.
+
+        private val KEY_ANSTIEG_AKTIV = booleanPreferencesKey("weckton_anstieg_aktiv")
+        private val KEY_ANSTIEG_SEKUNDEN = intPreferencesKey("weckton_anstieg_sekunden")
+        private val KEY_ANSTIEG_START_PROZENT = intPreferencesKey("weckton_anstieg_start_prozent")
+
+        /**
+         * AUS als Vorgabe - und das ist eine Entscheidung, keine Bequemlichkeit.
+         *
+         * Wer die App aktualisiert, hat sich an sein Weckverhalten gewoehnt. Eine stille
+         * Umstellung auf "startet leise" waere eine Aenderung am Wecker selbst, die niemand
+         * bestellt hat und die man erst bemerkt, wenn man verschlafen hat.
+         */
+        const val DEFAULT_ANSTIEG_AKTIV = false
+
+        /** Vorgabe, sobald der Nutzer den Anstieg einschaltet. */
+        const val DEFAULT_ANSTIEG_SEKUNDEN = 30
+        const val DEFAULT_ANSTIEG_START_PROZENT = 15
+
+        /**
+         * Grenzen, geklemmt beim LESEN und beim SCHREIBEN - aus demselben Grund wie bei der
+         * Schlummer-Dauer (Android-Backup, Export/Import, aeltere Versionen), aber mit einem
+         * zusaetzlichen: hier haengt die Weckwirkung selbst daran.
+         *
+         * Die OBERgrenze der Dauer ist der eigentliche Schutz. Ein Anstieg ueber viele Minuten
+         * ist kein sanfter Wecker mehr, sondern ein spaeterer - wer um 04:30 zur Fruehschicht
+         * muss, verliert die Zeit ersatzlos. 120 s sind laut Erfahrungswerten deutlich mehr, als
+         * ein Anstieg braucht, und trotzdem eine Grenze, hinter der die Weckzeit noch die
+         * Weckzeit ist.
+         *
+         * Der Startpegel darf 100 sein (dann ist der Anstieg wirkungslos, aber harmlos) und nie
+         * 0: `0` bliebe bis zum letzten Schritt stumm und wuerde dann schlagartig laut - siehe
+         * [LautstaerkeAnstieg.MIN_STARTPEGEL].
+         */
+        const val MIN_ANSTIEG_SEKUNDEN = 5
+        const val MAX_ANSTIEG_SEKUNDEN = 120
+        const val MIN_ANSTIEG_START_PROZENT = 1
+        const val MAX_ANSTIEG_START_PROZENT = 100
     }
 
     /**
@@ -95,5 +142,88 @@ class AlarmPrefs @Inject constructor(
 
     suspend fun setSnoozeMinutes(v: Int) = dataStore.edit {
         it[KEY_SNOOZE_MINUTES] = v.coerceIn(MIN_SNOOZE_MINUTES, MAX_SNOOZE_MINUTES)
+    }
+
+    // ---- Sanfter Weckton-Anstieg -----------------------------------------------------------
+
+    /**
+     * Die drei Werte des Anstiegs als EIN Flow.
+     *
+     * Zusammen und nicht einzeln, weil sie zusammen gelesen werden: `AlarmReceiver` holt sie
+     * einmal pro Alarm-Feuern und reicht sie als Intent-Extras an den `AlarmSoundService` durch -
+     * derselbe Weg wie bei der Schlummer-Dauer und aus demselben Grund (der Service darf im
+     * Weckpfad keinen DataStore-Read bekommen). Drei einzelne `first()`-Aufrufe waeren drei
+     * Gelegenheiten zu scheitern, wo eine reicht.
+     *
+     * Das `.catch` steht HINTER dem `.map` (die Reihenfolge ist tragend, siehe CLAUDE.md,
+     * "Persistenz"). Degradiert wird auf [WecktonAnstieg.AUS], also auf volle Lautstaerke ab der
+     * ersten Sekunde: Ein Lesefehler darf den Wecker lauter machen, niemals leiser.
+     */
+    val wecktonAnstieg: Flow<WecktonAnstieg> = dataStore.data
+        .map { prefs ->
+            WecktonAnstieg(
+                aktiv = prefs[KEY_ANSTIEG_AKTIV] ?: DEFAULT_ANSTIEG_AKTIV,
+                sekunden = (prefs[KEY_ANSTIEG_SEKUNDEN] ?: DEFAULT_ANSTIEG_SEKUNDEN)
+                    .coerceIn(MIN_ANSTIEG_SEKUNDEN, MAX_ANSTIEG_SEKUNDEN),
+                startProzent = (prefs[KEY_ANSTIEG_START_PROZENT] ?: DEFAULT_ANSTIEG_START_PROZENT)
+                    .coerceIn(MIN_ANSTIEG_START_PROZENT, MAX_ANSTIEG_START_PROZENT)
+            )
+        }
+        .catch { e ->
+            Logger.e(
+                LogTags.ALARM,
+                "Weckton-Anstieg nicht lesbar - der Wecker klingelt ohne Anstieg, also sofort laut",
+                e
+            )
+            emit(WecktonAnstieg.AUS)
+        }
+
+    suspend fun wecktonAnstiegNow(): WecktonAnstieg = wecktonAnstieg.first()
+
+    suspend fun setAnstiegAktiv(v: Boolean) = dataStore.edit {
+        it[KEY_ANSTIEG_AKTIV] = v
+    }
+
+    suspend fun setAnstiegSekunden(v: Int) = dataStore.edit {
+        it[KEY_ANSTIEG_SEKUNDEN] = v.coerceIn(MIN_ANSTIEG_SEKUNDEN, MAX_ANSTIEG_SEKUNDEN)
+    }
+
+    suspend fun setAnstiegStartProzent(v: Int) = dataStore.edit {
+        it[KEY_ANSTIEG_START_PROZENT] = v.coerceIn(MIN_ANSTIEG_START_PROZENT, MAX_ANSTIEG_START_PROZENT)
+    }
+}
+
+/**
+ * Die Einstellung des sanften Weckton-Anstiegs, wie sie beim Feuern gilt.
+ *
+ * @param aktiv Ist der Anstieg eingeschaltet?
+ * @param sekunden Dauer bis zur vollen Lautstaerke.
+ * @param startProzent Anfangspegel in Prozent der eingestellten Alarm-Lautstaerke.
+ */
+data class WecktonAnstieg(
+    val aktiv: Boolean,
+    val sekunden: Int,
+    val startProzent: Int
+) {
+    /**
+     * Dauer fuer [LautstaerkeAnstieg.pegel] - `0`, solange der Anstieg aus ist. Damit gibt es nur
+     * EINE Stelle, an der "aus" in "keine Dauer" uebersetzt wird, statt eines `if (aktiv)` an
+     * jedem Nutzungsort.
+     */
+    val dauerMs: Long get() = if (aktiv) sekunden * 1000L else 0L
+
+    /** Startpegel als Faktor fuer `MediaPlayer.setVolume()`. */
+    val startAnteil: Float get() = startProzent / 100f
+
+    companion object {
+        /**
+         * Kein Anstieg: volle Lautstaerke ab der ersten Sekunde. Das Ziel jeder Degradation und
+         * der Zustand im Direct Boot, wo der DataStore nicht lesbar ist.
+         */
+        val AUS = WecktonAnstieg(
+            aktiv = false,
+            sekunden = AlarmPrefs.DEFAULT_ANSTIEG_SEKUNDEN,
+            startProzent = AlarmPrefs.DEFAULT_ANSTIEG_START_PROZENT
+        )
     }
 }

--- a/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/alarm/LautstaerkeAnstieg.kt
+++ b/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/alarm/LautstaerkeAnstieg.kt
@@ -1,0 +1,97 @@
+package com.github.f1rlefanz.cf_alarmfortimeoffice.alarm
+
+import kotlin.math.pow
+
+/**
+ * Rechnet den Pegel des sanften Weckton-Anstiegs aus - der EINZIGE Ort, an dem diese Kurve
+ * entsteht. Reine Funktionen, deshalb unter Test (`LautstaerkeAnstiegTest`).
+ *
+ * ## Was hier NICHT passiert
+ *
+ * Der Anstieg ruehrt die **System-Lautstaerke nicht an**. Er skaliert ausschliesslich den eigenen
+ * [android.media.MediaPlayer] per `setVolume()`, also relativ zu dem, was der Nutzer am
+ * Alarm-Regler eingestellt hat. Der naheliegende Weg
+ * `AudioManager.setStreamVolume(STREAM_ALARM, ...)` waere ein Griff in eine SYSTEMWEITE
+ * Einstellung: stirbt der Prozess mitten im Anstieg - und ein Wecker laeuft nun einmal nachts,
+ * ohne dass jemand zusieht - bliebe die Alarm-Lautstaerke des Geraets dauerhaft auf dem
+ * Anfangswert stehen. Das naechste Wecken waere dann leise, ohne dass irgendetwas darauf
+ * hinweist. Ein per `setVolume()` skalierter Player kann diesen Schaden nicht anrichten: er
+ * verschwindet mit dem Player.
+ *
+ * ## Warum die Kurve nicht linear ist
+ *
+ * `setVolume()` nimmt eine AMPLITUDE, das Ohr hoert aber ungefaehr logarithmisch. Ein linear
+ * ansteigender Amplitudenwert klingt deshalb so, als schoesse die Lautstaerke am Anfang hoch und
+ * bliebe danach fast stehen - genau verkehrt herum fuer einen Wecker, der sanft anlaufen soll.
+ *
+ * Deshalb wird zwischen Startpegel und 1,0 GEOMETRISCH interpoliert (gleichbedeutend mit: linear
+ * in Dezibel). Das ergibt einen als gleichmaessig empfundenen Anstieg:
+ *
+ * ```
+ * pegel(p) = start^(1 - p)      p = vergangene Zeit / Dauer, geklemmt auf 0..1
+ * ```
+ *
+ * Bei p = 0 steht dort `start`, bei p = 1 exakt `1.0` - die Kurve trifft beide Enden genau, ohne
+ * Rundungsrest. Genau das ist der Grund fuer diese Form statt einer Potenzkurve mit Offset: das
+ * Ende MUSS die volle Lautstaerke sein, nicht 0,98 davon.
+ *
+ * ## Richtung der Degradation
+ *
+ * Jede unklare Eingabe fuehrt zu **1,0**, also zu voller Lautstaerke ab der ersten Sekunde -
+ * dem Verhalten ohne Anstieg. Ein zu lauter Wecker weckt; ein zu leiser ist der schwerste
+ * denkbare Fehler dieser App. Im Zweifel klingeln.
+ */
+object LautstaerkeAnstieg {
+
+    /**
+     * Abstand zwischen zwei Pegelschritten.
+     *
+     * 200 ms sind fein genug, dass man keine Stufen hoert (bei 30 s Anstieg sind das 150
+     * Schritte), und grob genug, dass die Schrittkette neben einem klingelnden Wecker nicht ins
+     * Gewicht faellt. Ein `setVolume()`-Aufruf kostet praktisch nichts.
+     */
+    const val SCHRITT_MS = 200L
+
+    /** Voller Pegel - der Wert, auf den jede Unklarheit degradiert. */
+    const val VOLL = 1.0f
+
+    /**
+     * Untergrenze fuer den Startpegel beim RECHNEN (nicht beim Speichern - dafuer sorgt
+     * [AlarmPrefs]). Verhindert, dass `0` als Startpegel hereinkommt: `0^(1-p)` ist fuer jedes
+     * p < 1 ebenfalls 0, der Wecker bliebe also bis zum letzten Schritt voellig stumm und wuerde
+     * dann schlagartig laut. Das ist kein Anstieg, sondern eine verspaetete Ausloesung.
+     */
+    const val MIN_STARTPEGEL = 0.01f
+
+    /**
+     * @param startAnteil Pegel zu Beginn, 0..1 (z. B. 0,15 fuer 15 % der eingestellten
+     *   Alarm-Lautstaerke).
+     * @param dauerMs Dauer des Anstiegs bis zur vollen Lautstaerke. `<= 0` heisst "kein Anstieg".
+     * @param vergangenMs seit dem Start des Tons vergangene Zeit.
+     * @return Faktor fuer `MediaPlayer.setVolume()`, immer in `[MIN_STARTPEGEL, 1.0]`.
+     */
+    fun pegel(startAnteil: Float, dauerMs: Long, vergangenMs: Long): Float {
+        // Kein Anstieg gewuenscht, oder die Eingaben sind unbrauchbar (NaN faellt hier ebenfalls
+        // heraus, weil jeder Vergleich mit NaN false ergibt und das `!` ihn einfaengt).
+        if (dauerMs <= 0L) return VOLL
+        if (!(startAnteil > 0f) || startAnteil >= VOLL) return VOLL
+
+        val start = startAnteil.coerceAtLeast(MIN_STARTPEGEL)
+        val fortschritt = (vergangenMs.toDouble() / dauerMs.toDouble()).coerceIn(0.0, 1.0)
+
+        // Bereits am Ende: exakt VOLL zurueckgeben statt start^0 zu rechnen - kein Rundungsrest.
+        if (fortschritt >= 1.0) return VOLL
+
+        return start.toDouble().pow(1.0 - fortschritt).toFloat().coerceIn(start, VOLL)
+    }
+
+    /**
+     * Wie lange nach dem Start noch nachgeregelt werden muss.
+     *
+     * Der Aufrufer plant damit seinen Backstop - den einen Handler-Aufruf, der am Ende
+     * bedingungslos auf [VOLL] stellt, falls die Schrittkette unterwegs abgerissen ist. Ein
+     * Schritt Zuschlag, damit der Backstop garantiert NACH dem letzten regulaeren Schritt liegt
+     * und nicht mit ihm um denselben Millisekundenwert konkurriert.
+     */
+    fun backstopVerzoegerungMs(dauerMs: Long): Long = dauerMs + SCHRITT_MS
+}

--- a/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/backup/ConfigBackupFormat.kt
+++ b/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/backup/ConfigBackupFormat.kt
@@ -1,5 +1,6 @@
 package com.github.f1rlefanz.cf_alarmfortimeoffice.backup
 
+import com.github.f1rlefanz.cf_alarmfortimeoffice.alarm.AlarmPrefs
 import com.github.f1rlefanz.cf_alarmfortimeoffice.alarm.FeedNeueinlesenStore
 import com.github.f1rlefanz.cf_alarmfortimeoffice.alarm.SyncHorizonStore
 import com.github.f1rlefanz.cf_alarmfortimeoffice.calendar.PendingDeselectionCleanupStore
@@ -246,14 +247,27 @@ object ConfigBackupFilter {
      *   - `dnd_oncall_cutoff_min`: `DndOnCallCutoffResolver` rechnet
      *     `LocalTime.ofSecondOfDay(cutoffMinutes * 60L)`. Negativ oder >= 1440 wirft eine
      *     `DateTimeException` - der DND-Tick stirbt dann bei jedem Lauf.
+     *   - `weckton_anstieg_sekunden` / `weckton_anstieg_start_prozent`: beide bestimmen, WIE LEISE
+     *     und WIE LANGE der Wecker anlaeuft. Eine Datei mit `3600` Sekunden oder `1` Prozent
+     *     ergaebe einen Wecker, den man nicht hoert - und zwar ohne jede Fehlermeldung, denn beide
+     *     Werte sind fuer sich genommen gueltige Zahlen. Der Lesepfad klemmt sie zwar (`AlarmPrefs`),
+     *     aber hier wird der Nutzer nach einem Import auch DARUEBER INFORMIERT, statt den Wert
+     *     stillschweigend zurechtzubiegen.
      *
-     * Bewusst NUR diese beiden: fuer alles andere ist eine Klemme im Lesepfad die richtige Ebene,
+     * Bewusst NUR diese vier: fuer alles andere ist eine Klemme im Lesepfad die richtige Ebene,
      * und die ist dort vorhanden. Dieser Katalog ist keine zweite Validierungsschicht fuer alles,
      * sondern der Schutz an der Stelle, an der FREMDE Daten hereinkommen.
      */
     private val PLAUSIBLE_INT_RANGES: Map<String, IntRange> = mapOf(
         "snooze_minutes" to 1..120,
-        "dnd_oncall_cutoff_min" to 0..(24 * 60 - 1)
+        "dnd_oncall_cutoff_min" to 0..(24 * 60 - 1),
+        // Die Grenzen kommen aus AlarmPrefs statt als Zahlen hierher: `const val` wird beim
+        // Uebersetzen eingesetzt, kostet also nichts - aber eine spaetere Aenderung dort kann
+        // nicht mehr an diesem Katalog vorbeilaufen.
+        "weckton_anstieg_sekunden" to
+            AlarmPrefs.MIN_ANSTIEG_SEKUNDEN..AlarmPrefs.MAX_ANSTIEG_SEKUNDEN,
+        "weckton_anstieg_start_prozent" to
+            AlarmPrefs.MIN_ANSTIEG_START_PROZENT..AlarmPrefs.MAX_ANSTIEG_START_PROZENT
     )
 
     /**

--- a/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/backup/ConfigBackupUseCase.kt
+++ b/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/backup/ConfigBackupUseCase.kt
@@ -348,7 +348,12 @@ class ConfigBackupUseCase @Inject constructor(
         }
 
         /** Schluessel, deren Typ auch ohne lokalen Bestand feststeht (beide zusaetzlich geklemmt). */
-        private val KNOWN_INT_KEYS = setOf("snooze_minutes", "dnd_oncall_cutoff_min")
+        private val KNOWN_INT_KEYS = setOf(
+            "snooze_minutes",
+            "dnd_oncall_cutoff_min",
+            "weckton_anstieg_sekunden",
+            "weckton_anstieg_start_prozent"
+        )
 
         private fun typeNameOf(value: Any?): String? = when (value) {
             is Boolean -> "boolean"

--- a/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/service/AlarmSoundService.kt
+++ b/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/service/AlarmSoundService.kt
@@ -18,6 +18,7 @@ import android.os.Handler
 import android.os.IBinder
 import android.os.Looper
 import android.os.PowerManager
+import android.os.SystemClock
 import android.os.VibrationEffect
 import android.os.Vibrator
 import android.os.VibratorManager
@@ -26,7 +27,10 @@ import androidx.core.app.NotificationManagerCompat
 import com.github.f1rlefanz.cf_alarmfortimeoffice.AlarmFullScreenActivity
 import com.github.f1rlefanz.cf_alarmfortimeoffice.MainActivity
 import com.github.f1rlefanz.cf_alarmfortimeoffice.R
+import com.github.f1rlefanz.cf_alarmfortimeoffice.alarm.AlarmPrefs
+import com.github.f1rlefanz.cf_alarmfortimeoffice.alarm.LautstaerkeAnstieg
 import com.github.f1rlefanz.cf_alarmfortimeoffice.alarm.VorweckEntscheidung
+import com.github.f1rlefanz.cf_alarmfortimeoffice.alarm.WecktonAnstieg
 import com.github.f1rlefanz.cf_alarmfortimeoffice.util.LogTags
 import com.github.f1rlefanz.cf_alarmfortimeoffice.util.Logger
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -98,6 +102,21 @@ class AlarmSoundService : Service() {
         // AlarmFullScreenActivity) lesen sie synchron aus dem Intent statt selbst den DataStore
         // anzufassen - siehe AlarmPrefs-Klassenkommentar.
         const val EXTRA_SNOOZE_MINUTES = "snooze_minutes"
+
+        /**
+         * Der sanfte Weckton-Anstieg, aufgeteilt in drei Extras.
+         *
+         * Wie [EXTRA_SNOOZE_MINUTES] ueber den Intent und nicht per DataStore-Read hier im
+         * Dienst: Der Weckpfad darf keine Lesezugriffe bekommen, die scheitern oder haengen
+         * koennen (Hergang bei `AlarmPrefs`). `AlarmReceiver` liest die Werte einmal pro Feuern.
+         *
+         * FEHLEN sie, gilt "kein Anstieg" - volle Lautstaerke ab der ersten Sekunde. Genau das
+         * ist der Direct-Boot-Fall: dort liest der Receiver den CE-Storage bewusst nicht, und
+         * ein Wecker vor der ersten Entsperrung soll ohnehin nicht leise anlaufen.
+         */
+        const val EXTRA_ANSTIEG_AKTIV = "weckton_anstieg_aktiv"
+        const val EXTRA_ANSTIEG_SEKUNDEN = "weckton_anstieg_sekunden"
+        const val EXTRA_ANSTIEG_START_PROZENT = "weckton_anstieg_start_prozent"
 
         private const val VORWECK_LOCK_TAG = "CFAlarm:VorweckenFuerWeckbildschirm"
 
@@ -262,6 +281,22 @@ class AlarmSoundService : Service() {
     // OnPreparedListener callbacks from a previous player can never start playback.
     @Volatile
     private var playerGeneration = 0
+
+    /**
+     * Eigener Handler NUR fuer den Lautstaerke-Anstieg - bewusst nicht der [vorweckHandler].
+     *
+     * Beide raeumen mit `removeCallbacksAndMessages(null)` auf, was ALLE Nachrichten des
+     * Handlers loescht. Auf einem gemeinsamen Handler wuerde das Abbrechen des Anstiegs damit
+     * auch den ausstehenden Vordergrund-Start abraeumen - und das ist die eine Nachricht, die
+     * niemals verlorengehen darf.
+     */
+    private val anstiegHandler = Handler(Looper.getMainLooper())
+
+    /**
+     * Der Anstieg des LAUFENDEN Weckvorgangs. Wird bei jedem ACTION_START_ALARM aus dem Intent
+     * neu gesetzt, damit ein zweiter Wecker nicht die Einstellung des ersten erbt.
+     */
+    private var anstieg: WecktonAnstieg = WecktonAnstieg.AUS
     
     /**
      * Reiner Started-Service, kein Binding.
@@ -282,6 +317,24 @@ class AlarmSoundService : Service() {
                 val snoozeMinutes = intent.getIntExtra(
                     EXTRA_SNOOZE_MINUTES,
                     AlarmManagerService.SNOOZE_MINUTES.toInt()
+                )
+
+                // Fehlende Extras ergeben WecktonAnstieg.AUS - siehe [EXTRA_ANSTIEG_AKTIV].
+                // Erneut geklemmt, obwohl AlarmPrefs beim Lesen schon klemmt: Der Wert kommt
+                // hier aus einem Intent, und die Klemme kostet nichts.
+                anstieg = WecktonAnstieg(
+                    aktiv = intent.getBooleanExtra(EXTRA_ANSTIEG_AKTIV, false),
+                    sekunden = intent.getIntExtra(
+                        EXTRA_ANSTIEG_SEKUNDEN,
+                        AlarmPrefs.DEFAULT_ANSTIEG_SEKUNDEN
+                    ).coerceIn(AlarmPrefs.MIN_ANSTIEG_SEKUNDEN, AlarmPrefs.MAX_ANSTIEG_SEKUNDEN),
+                    startProzent = intent.getIntExtra(
+                        EXTRA_ANSTIEG_START_PROZENT,
+                        AlarmPrefs.DEFAULT_ANSTIEG_START_PROZENT
+                    ).coerceIn(
+                        AlarmPrefs.MIN_ANSTIEG_START_PROZENT,
+                        AlarmPrefs.MAX_ANSTIEG_START_PROZENT
+                    )
                 )
 
                 Logger.business(
@@ -586,6 +639,7 @@ class AlarmSoundService : Service() {
         // Guaranteed cleanup on service destruction
         _alarmActive.value = false
         vorweckHandler.removeCallbacksAndMessages(null)
+        anstiegHandler.removeCallbacksAndMessages(null)
         gibVorweckLockFrei()
         stopAlarmSound()
         stopVibration()
@@ -722,6 +776,9 @@ class AlarmSoundService : Service() {
                         // Guard: only start if this is still the active player
                         if (!isShuttingDown && myGeneration == playerGeneration) {
                             try {
+                                // Startpegel VOR start(): andernfalls waere der erste Moment
+                                // voll laut und der Anstieg begaenne mit einem Knall.
+                                starteAnstieg(player, myGeneration)
                                 player.start()
                                 Logger.business(LogTags.ALARM, "✅ MediaPlayer started successfully in service")
                             } catch (e: Exception) {
@@ -764,6 +821,89 @@ class AlarmSoundService : Service() {
     }
 
     /**
+     * Startet den sanften Lautstaerke-Anstieg fuer [player] - oder stellt sofort auf volle
+     * Lautstaerke, wenn keiner eingestellt ist.
+     *
+     * ## Drei Sicherungen, und warum jede einzelne noetig ist
+     *
+     * Ein Anstieg ist die einzige Stelle dieser App, an der der Wecker ABSICHTLICH leise
+     * anfaengt. Bleibt er dort haengen, ist das Ergebnis ein Wecker, den man verschlaeft - und
+     * niemand steht daneben, um es zu bemerken. Deshalb:
+     *
+     * 1. **Generationsschutz**: Jeder Callback prueft [playerGeneration]. Ein Anstieg, der noch
+     *    zum vorigen Player gehoert, darf den neuen nicht leiser drehen (Fall: stop -> snooze ->
+     *    start in schneller Folge, derselbe Race, gegen den der OnPreparedListener sich schuetzt).
+     * 2. **Backstop**: Ein zweiter, von der Schrittkette UNABHAENGIGER Handler-Aufruf stellt am
+     *    Ende bedingungslos auf volle Lautstaerke. Reisst die Kette unterwegs ab - eine Exception
+     *    in einem Schritt, ein verworfener Callback -, waere der Wecker sonst dauerhaft auf dem
+     *    Anfangspegel eingefroren. Die Kette darf ausfallen, das Ergebnis nicht.
+     * 3. **Kein `return` in den Fehlerzweig**: Scheitert [setzePegel], laeuft die Kette weiter.
+     *    Der naechste Schritt liegt hoeher, nicht tiefer - ein misslungener Schritt darf den
+     *    Anstieg nicht auf dem aktuellen Stand festnageln.
+     *
+     * @param generation die Generation des Players, fuer den dieser Anstieg gilt.
+     */
+    private fun starteAnstieg(player: MediaPlayer, generation: Int) {
+        anstiegHandler.removeCallbacksAndMessages(null)
+
+        val dauerMs = anstieg.dauerMs
+        if (dauerMs <= 0L) {
+            // Kein Anstieg: ausdruecklich auf voll stellen statt sich auf die Vorgabe des
+            // MediaPlayers zu verlassen. Der Player ist zwar frisch, aber "volle Lautstaerke"
+            // ist bei einem Wecker nichts, was man voraussetzt.
+            setzePegel(player, LautstaerkeAnstieg.VOLL)
+            return
+        }
+
+        val startAnteil = anstieg.startAnteil
+        val beginn = SystemClock.elapsedRealtime()
+        setzePegel(player, LautstaerkeAnstieg.pegel(startAnteil, dauerMs, 0L))
+
+        val schritt = object : Runnable {
+            override fun run() {
+                if (isShuttingDown || generation != playerGeneration) return
+                val vergangen = SystemClock.elapsedRealtime() - beginn
+                setzePegel(player, LautstaerkeAnstieg.pegel(startAnteil, dauerMs, vergangen))
+                if (vergangen < dauerMs) {
+                    anstiegHandler.postDelayed(this, LautstaerkeAnstieg.SCHRITT_MS)
+                }
+            }
+        }
+        anstiegHandler.postDelayed(schritt, LautstaerkeAnstieg.SCHRITT_MS)
+
+        anstiegHandler.postDelayed(
+            {
+                if (!isShuttingDown && generation == playerGeneration) {
+                    setzePegel(player, LautstaerkeAnstieg.VOLL)
+                }
+            },
+            LautstaerkeAnstieg.backstopVerzoegerungMs(dauerMs)
+        )
+
+        Logger.business(
+            LogTags.ALARM,
+            "🔉 Weckton-Anstieg: ${anstieg.startProzent} % -> 100 % in ${anstieg.sekunden} s"
+        )
+    }
+
+    /**
+     * Setzt den Pegel des Players - relativ zur Alarm-Lautstaerke des Systems, die dabei
+     * unangetastet bleibt (siehe [LautstaerkeAnstieg]).
+     *
+     * Der Fehler wird geschluckt und nur geloggt: `setVolume()` wirft auf einem bereits
+     * freigegebenen Player, und das passiert im normalen Ablauf, wenn Abstellen und Anstieg sich
+     * um Millisekunden ueberschneiden. Eine Exception aus einem Handler-Callback wuerde den
+     * Prozess reissen - waehrend der Wecker klingelt.
+     */
+    private fun setzePegel(player: MediaPlayer, pegel: Float) {
+        try {
+            player.setVolume(pegel, pegel)
+        } catch (e: Exception) {
+            Logger.w(LogTags.ALARM, "⚠️ Lautstaerke nicht setzbar (Pegel $pegel)", e)
+        }
+    }
+
+    /**
      * Stops alarm sound and releases MediaPlayer.
      *
      * Sets isShuttingDown first, then increments playerGeneration so that any
@@ -772,6 +912,10 @@ class AlarmSoundService : Service() {
     private fun stopAlarmSound() {
         isShuttingDown = true
         playerGeneration++ // invalidate any pending OnPreparedListener callbacks
+        // Schrittkette UND Backstop des Anstiegs abraeumen. Beide pruefen zwar zusaetzlich die
+        // Generation, aber ein Callback auf einem freigegebenen MediaPlayer soll gar nicht erst
+        // laufen muessen.
+        anstiegHandler.removeCallbacksAndMessages(null)
 
         try {
             alarmMediaPlayer?.let { player ->

--- a/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/ui/screens/MainContentScreen.kt
+++ b/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/ui/screens/MainContentScreen.kt
@@ -120,6 +120,9 @@ fun MainContentScreen(
     val tagFreigabeState by alarmViewModel.tagFreigabeState.collectAsStateWithLifecycle()
     val manualAlarmState by alarmViewModel.manualAlarmState.collectAsStateWithLifecycle() // NEU
     val snoozeMinutes by alarmViewModel.snoozeMinutes.collectAsStateWithLifecycle()
+    // Wie snoozeMinutes: reine Anzeige. Beim Feuern liest AlarmReceiver die Werte einmal
+    // direkt aus AlarmPrefs - der Wecker haengt nicht an diesem Flow.
+    val wecktonAnstieg by alarmViewModel.wecktonAnstieg.collectAsStateWithLifecycle()
     // EINE Sammelstelle fuer die Master-Pause, von hier an drei Tabs verteilt (Home, Wecker,
     // Status). WARUM UEBERHAUPT: Die Pause loescht alle Wecker, stoppt die 6h-Wartung, Dimmer,
     // "Nicht stoeren" und Hue - und war bis dahin ausschliesslich am Schalter ganz unten im
@@ -365,6 +368,7 @@ fun MainContentScreen(
                         skipState = skipState,
                         tagFreigabeState = tagFreigabeState,
                         snoozeMinutes = snoozeMinutes,
+                        wecktonAnstieg = wecktonAnstieg,
                         masterPausePaused = masterPausePaused,
                         onUpdateShiftConfig = shiftViewModel::updateShiftConfig,
                         onSkipNextAlarm = alarmViewModel::skipNextAlarm,
@@ -392,7 +396,10 @@ fun MainContentScreen(
                             }
                         },
                         onShowShiftConfig = onShowShiftConfig,
-                        onSnoozeMinutesChange = alarmViewModel::setSnoozeMinutes
+                        onSnoozeMinutesChange = alarmViewModel::setSnoozeMinutes,
+                        onAnstiegAktivChange = alarmViewModel::setAnstiegAktiv,
+                        onAnstiegSekundenChange = alarmViewModel::setAnstiegSekunden,
+                        onAnstiegStartProzentChange = alarmViewModel::setAnstiegStartProzent
                     )
                 }
                 MainTab.STATUS -> {

--- a/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/ui/screens/tabs/WeckerTabContent.kt
+++ b/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/ui/screens/tabs/WeckerTabContent.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.github.f1rlefanz.cf_alarmfortimeoffice.alarm.WecktonAnstieg
 import com.github.f1rlefanz.cf_alarmfortimeoffice.model.ShiftConfig
 import com.github.f1rlefanz.cf_alarmfortimeoffice.ui.components.AlarmStatusHeader
 import com.github.f1rlefanz.cf_alarmfortimeoffice.ui.components.CompactButton
@@ -63,6 +64,24 @@ import java.util.Locale
 
 /** Auswahlmoeglichkeiten fuer die Schlummer-Dauer-Dropdown - deckt die ueblichen Werte ab. */
 private val SNOOZE_MINUTES_OPTIONS = listOf(3, 5, 10, 15)
+
+/**
+ * Anlaufzeiten des sanften Weckton-Anstiegs, in Sekunden.
+ *
+ * Die Liste endet bei 120 s, weil
+ * [com.github.f1rlefanz.cf_alarmfortimeoffice.alarm.AlarmPrefs.MAX_ANSTIEG_SEKUNDEN] dort endet - ein laengerer
+ * Anlauf ist kein sanfterer Wecker mehr, sondern ein spaeterer.
+ */
+private val ANSTIEG_SEKUNDEN_OPTIONS = listOf(10, 15, 30, 45, 60, 90, 120)
+
+/**
+ * Startlautstaerken in Prozent der am Geraet eingestellten Alarm-Lautstaerke.
+ *
+ * Kein Wert unter 5 %: darunter ist der Anfang auf den meisten Geraeten schlicht nicht mehr zu
+ * hoeren, und ein Wecker, dessen erste Sekunden wirkungslos verstreichen, ist kein sanfter
+ * Wecker, sondern ein kuerzerer.
+ */
+private val ANSTIEG_START_PROZENT_OPTIONS = listOf(5, 10, 15, 25, 40, 60)
 
 /** Beschreibung des Schalters im Normalfall - beschreibt, was ein Umlegen wirklich tut. */
 internal const val AUTO_ALARM_BESCHREIBUNG_NORMAL: String =
@@ -157,6 +176,7 @@ fun WeckerTabContent(
     skipState: AlarmSkipUiState,
     tagFreigabeState: TagFreigabeUiState,
     snoozeMinutes: Int,
+    wecktonAnstieg: WecktonAnstieg,
     masterPausePaused: Boolean,
     onUpdateShiftConfig: (ShiftConfig) -> Unit,
     onSkipNextAlarm: () -> Unit,
@@ -164,7 +184,10 @@ fun WeckerTabContent(
     onTagFreigeben: (LocalDate) -> Unit,
     onFreigabeZuruecknehmen: (LocalDate) -> Unit,
     onShowShiftConfig: () -> Unit,
-    onSnoozeMinutesChange: (Int) -> Unit
+    onSnoozeMinutesChange: (Int) -> Unit,
+    onAnstiegAktivChange: (Boolean) -> Unit,
+    onAnstiegSekundenChange: (Int) -> Unit,
+    onAnstiegStartProzentChange: (Int) -> Unit
 ) {
     Column(
         modifier = Modifier
@@ -219,6 +242,15 @@ fun WeckerTabContent(
                 SnoozeMinutesRow(
                     snoozeMinutes = snoozeMinutes,
                     onSnoozeMinutesChange = onSnoozeMinutesChange
+                )
+
+                HorizontalDivider(modifier = Modifier.padding(vertical = SpacingConstants.SPACING_MEDIUM))
+
+                WecktonAnstiegAbschnitt(
+                    anstieg = wecktonAnstieg,
+                    onAktivChange = onAnstiegAktivChange,
+                    onSekundenChange = onAnstiegSekundenChange,
+                    onStartProzentChange = onAnstiegStartProzentChange
                 )
             }
         }
@@ -615,6 +647,101 @@ private fun SnoozeMinutesRow(
     snoozeMinutes: Int,
     onSnoozeMinutesChange: (Int) -> Unit
 ) {
+    AuswahlRow(
+        titel = "Schlummer-Dauer",
+        beschreibung = "Gilt für Vollbild und Benachrichtigung",
+        optionen = SNOOZE_MINUTES_OPTIONS,
+        beschriftung = { "$it Min" },
+        aktuellerWert = snoozeMinutes,
+        aenderungsBeschreibung = "Schlummer-Dauer ändern",
+        onAuswahl = onSnoozeMinutesChange
+    )
+}
+
+/**
+ * Der sanfte Weckton-Anstieg: Schalter plus die beiden Werte, die ihn beschreiben.
+ *
+ * ## Warum es diesen Abschnitt gibt - und warum daneben KEINE Ton- oder Lautstaerkeauswahl steht
+ *
+ * Weckton und Lautstaerke kommen vollstaendig aus den Android-Einstellungen: der Ton ist der
+ * Standard-Alarmton des Geraets, die Lautstaerke der Alarm-Regler. Eine eigene Auswahl daneben
+ * waere eine zweite Wahrheit ohne Gewinn - und eine Stelle, an der die App leiser sein kann, als
+ * der Nutzer glaubt. Das EINE, was Android nicht anbietet, ist ein sanfter Anstieg. Nur der steht
+ * hier.
+ *
+ * ## Warum die beiden Werte nur bei eingeschaltetem Anstieg erscheinen
+ *
+ * Ausgeschaltet beschreiben sie nichts, was passiert. Ein bedienbares Dropdown, das folgenlos
+ * bleibt, ist genau die Art Oberflaeche, die man einmal einstellt und danach fuer wirksam haelt.
+ */
+@Composable
+private fun WecktonAnstiegAbschnitt(
+    anstieg: WecktonAnstieg,
+    onAktivChange: (Boolean) -> Unit,
+    onSekundenChange: (Int) -> Unit,
+    onStartProzentChange: (Int) -> Unit
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(SpacingConstants.SPACING_MEDIUM)
+    ) {
+        SwitchRow(
+            title = "Sanft lauter werden",
+            // Nennt beide Halbwahrheiten, auf die man sonst kommt: dass die App eine eigene
+            // Lautstaerke haette, und dass sie die des Geraets veraendert. Beides ist falsch -
+            // der Anstieg endet bei dem, was am Alarm-Regler eingestellt ist.
+            description = "Der Wecker beginnt leise und wird bis zu deiner eingestellten " +
+                "Alarm-Lautstärke lauter. Die Lautstärke des Geräts bleibt unverändert.",
+            checked = anstieg.aktiv,
+            onCheckedChange = onAktivChange,
+            titleStyle = MaterialTheme.typography.titleMedium
+        )
+
+        if (anstieg.aktiv) {
+            AuswahlRow(
+                titel = "Anlaufzeit",
+                beschreibung = "Bis zur vollen Lautstärke",
+                optionen = ANSTIEG_SEKUNDEN_OPTIONS,
+                beschriftung = { "$it s" },
+                aktuellerWert = anstieg.sekunden,
+                aenderungsBeschreibung = "Anlaufzeit ändern",
+                onAuswahl = onSekundenChange
+            )
+
+            AuswahlRow(
+                titel = "Startlautstärke",
+                beschreibung = "Anteil deiner Alarm-Lautstärke am Anfang",
+                optionen = ANSTIEG_START_PROZENT_OPTIONS,
+                beschriftung = { "$it %" },
+                aktuellerWert = anstieg.startProzent,
+                aenderungsBeschreibung = "Startlautstärke ändern",
+                onAuswahl = onStartProzentChange
+            )
+        }
+    }
+}
+
+/**
+ * Beschriftete Zeile mit Auswahlknopf rechts - eine Bauart fuer alle drei Wecker-Einstellungen.
+ *
+ * Zusammengefasst, als der Anstieg die zweite und dritte Zeile dieser Form brauchte: dieselbe
+ * Row, dasselbe Dropdown, dieselbe Barrierefreiheits-Falle dreimal nebeneinander waere dreimal
+ * die Gelegenheit, sie an einer Stelle zu vergessen.
+ *
+ * @param aktuellerWert wird auch dann angezeigt, wenn er nicht in [optionen] steht - der Wert kann
+ *   aus einem Import oder einer aelteren Version stammen. Ihn stillschweigend als eine der
+ *   Optionen darzustellen, waere eine Anzeige, die luegt.
+ */
+@Composable
+private fun AuswahlRow(
+    titel: String,
+    beschreibung: String,
+    optionen: List<Int>,
+    beschriftung: (Int) -> String,
+    aktuellerWert: Int,
+    aenderungsBeschreibung: String,
+    onAuswahl: (Int) -> Unit
+) {
     var expanded by remember { mutableStateOf(false) }
 
     Row(
@@ -623,12 +750,9 @@ private fun SnoozeMinutesRow(
         verticalAlignment = Alignment.CenterVertically
     ) {
         Column(modifier = Modifier.weight(1f)) {
+            Text(titel, style = MaterialTheme.typography.titleMedium)
             Text(
-                "Schlummer-Dauer",
-                style = MaterialTheme.typography.titleMedium
-            )
-            Text(
-                "Gilt für Vollbild und Benachrichtigung",
+                beschreibung,
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
@@ -636,19 +760,19 @@ private fun SnoozeMinutesRow(
 
         Box {
             OutlinedButton(onClick = { expanded = true }) {
-                Text("$snoozeMinutes Min")
-                // Nicht dekorativ: die Beschriftung des Knopfes ist nur "5 Min" - die Ueberschrift
-                // "Schlummer-Dauer" steht daneben in einer eigenen Spalte und wird nicht
-                // mitgelesen. Ohne diese Beschreibung meldet der Screenreader den Knopf als
-                // blosses "5 Min", ohne zu sagen, was er aendert.
-                Icon(Icons.Default.ArrowDropDown, contentDescription = "Schlummer-Dauer ändern")
+                Text(beschriftung(aktuellerWert))
+                // Nicht dekorativ: die Beschriftung des Knopfes ist nur der Wert - die
+                // Ueberschrift steht daneben in einer eigenen Spalte und wird nicht mitgelesen.
+                // Ohne diese Beschreibung meldet der Screenreader den Knopf als blosses "5 Min",
+                // ohne zu sagen, was er aendert.
+                Icon(Icons.Default.ArrowDropDown, contentDescription = aenderungsBeschreibung)
             }
             DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-                SNOOZE_MINUTES_OPTIONS.forEach { minutes ->
+                optionen.forEach { wert ->
                     DropdownMenuItem(
-                        text = { Text("$minutes Min") },
+                        text = { Text(beschriftung(wert)) },
                         onClick = {
-                            onSnoozeMinutesChange(minutes)
+                            onAuswahl(wert)
                             expanded = false
                         }
                     )

--- a/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/viewmodel/AlarmViewModel.kt
+++ b/app/src/main/java/com/github/f1rlefanz/cf_alarmfortimeoffice/viewmodel/AlarmViewModel.kt
@@ -3,6 +3,7 @@ package com.github.f1rlefanz.cf_alarmfortimeoffice.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.github.f1rlefanz.cf_alarmfortimeoffice.alarm.AlarmPrefs
+import com.github.f1rlefanz.cf_alarmfortimeoffice.alarm.WecktonAnstieg
 import com.github.f1rlefanz.cf_alarmfortimeoffice.error.ErrorHandler
 import com.github.f1rlefanz.cf_alarmfortimeoffice.freietage.FreigabeZurueckgenommenException
 import com.github.f1rlefanz.cf_alarmfortimeoffice.freietage.TagFreigabeUseCase
@@ -181,6 +182,16 @@ class AlarmViewModel @Inject constructor(
     val snoozeMinutes: StateFlow<Int> =
         alarmPrefs.snoozeMinutes
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), AlarmPrefs.DEFAULT_SNOOZE_MINUTES)
+
+    /**
+     * Der eingestellte sanfte Weckton-Anstieg - nur fuer die ANZEIGE im Wecker-Tab.
+     *
+     * Der Wecker haengt nicht daran: beim Feuern liest [com.github.f1rlefanz.cf_alarmfortimeoffice.AlarmReceiver]
+     * die Werte einmal direkt aus [AlarmPrefs] (gleiche Aufteilung wie bei [snoozeMinutes]).
+     */
+    val wecktonAnstieg: StateFlow<WecktonAnstieg> =
+        alarmPrefs.wecktonAnstieg
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), WecktonAnstieg.AUS)
 
     private val _skipState = MutableStateFlow(AlarmSkipUiState())
     val skipState: StateFlow<AlarmSkipUiState> = _skipState.asStateFlow()
@@ -454,6 +465,22 @@ class AlarmViewModel @Inject constructor(
         viewModelScope.launch {
             alarmPrefs.setSnoozeMinutes(minutes.coerceIn(1, 30))
         }
+    }
+
+    // ---- Sanfter Weckton-Anstieg ---------------------------------------------------------
+    // Geklemmt wird in AlarmPrefs (beim Schreiben UND beim Lesen) - hier bewusst kein zweiter
+    // Katalog von Grenzen, der mit dem ersten auseinanderlaufen kann.
+
+    fun setAnstiegAktiv(aktiv: Boolean) {
+        viewModelScope.launch { alarmPrefs.setAnstiegAktiv(aktiv) }
+    }
+
+    fun setAnstiegSekunden(sekunden: Int) {
+        viewModelScope.launch { alarmPrefs.setAnstiegSekunden(sekunden) }
+    }
+
+    fun setAnstiegStartProzent(prozent: Int) {
+        viewModelScope.launch { alarmPrefs.setAnstiegStartProzent(prozent) }
     }
 
     /**

--- a/app/src/test/java/com/github/f1rlefanz/cf_alarmfortimeoffice/alarm/LautstaerkeAnstiegTest.kt
+++ b/app/src/test/java/com/github/f1rlefanz/cf_alarmfortimeoffice/alarm/LautstaerkeAnstiegTest.kt
@@ -1,0 +1,128 @@
+package com.github.f1rlefanz.cf_alarmfortimeoffice.alarm
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Die Kurve des sanften Weckton-Anstiegs.
+ *
+ * WAS HIER GESCHUETZT WIRD: Der Anstieg ist die einzige Stelle dieser App, an der der Wecker
+ * ABSICHTLICH leise beginnt. Jeder Rechenfehler in dieser Datei ist damit ein potenziell
+ * verschlafener Dienst - und zwar einer, den kein Blick auf die Oberflaeche zeigt, weil die
+ * Einstellung ja richtig dasteht. Die beiden wichtigsten Zusicherungen sind deshalb nicht
+ * "die Kurve ist huebsch", sondern:
+ *
+ *  1. **Am Ende steht exakt volle Lautstaerke** - nicht 0,98 davon.
+ *  2. **Jede unklare Eingabe ergibt volle Lautstaerke**, nie einen leisen Wecker.
+ */
+class LautstaerkeAnstiegTest {
+
+    private val genauigkeit = 0.0001f
+
+    // ---- Die beiden Enden der Kurve ------------------------------------------------------
+
+    @Test
+    fun `am Anfang steht der eingestellte Startpegel`() {
+        assertEquals(0.15f, LautstaerkeAnstieg.pegel(0.15f, 30_000L, 0L), genauigkeit)
+    }
+
+    @Test
+    fun `am Ende steht exakt volle Lautstaerke`() {
+        assertEquals(
+            LautstaerkeAnstieg.VOLL,
+            LautstaerkeAnstieg.pegel(0.15f, 30_000L, 30_000L),
+            0f
+        )
+    }
+
+    @Test
+    fun `nach dem Ende bleibt es bei voller Lautstaerke`() {
+        // Der Backstop feuert einen Schritt NACH der Dauer, und die Schrittkette kann durch eine
+        // Verzoegerung des Handlers ebenfalls spaeter dran sein. Ueberschreitung darf deshalb
+        // nicht ueber 1,0 hinauslaufen - ein Pegel > 1,0 uebersteuert.
+        assertEquals(
+            LautstaerkeAnstieg.VOLL,
+            LautstaerkeAnstieg.pegel(0.15f, 30_000L, 999_000L),
+            0f
+        )
+    }
+
+    // ---- Richtung der Degradation: im Zweifel LAUT ----------------------------------------
+
+    @Test
+    fun `ohne Dauer gibt es keinen Anstieg`() {
+        assertEquals(LautstaerkeAnstieg.VOLL, LautstaerkeAnstieg.pegel(0.15f, 0L, 0L), 0f)
+    }
+
+    @Test
+    fun `negative Dauer ergibt volle Lautstaerke`() {
+        assertEquals(LautstaerkeAnstieg.VOLL, LautstaerkeAnstieg.pegel(0.15f, -1L, 0L), 0f)
+    }
+
+    @Test
+    fun `Startpegel null ergibt volle Lautstaerke statt Stille`() {
+        // Der gefaehrlichste Fall: 0 hoch irgendwas ist 0. Ohne diese Klemme bliebe der Wecker
+        // bis zum letzten Schritt voellig stumm.
+        assertEquals(LautstaerkeAnstieg.VOLL, LautstaerkeAnstieg.pegel(0f, 30_000L, 0L), 0f)
+    }
+
+    @Test
+    fun `negativer Startpegel ergibt volle Lautstaerke`() {
+        assertEquals(LautstaerkeAnstieg.VOLL, LautstaerkeAnstieg.pegel(-0.5f, 30_000L, 0L), 0f)
+    }
+
+    @Test
+    fun `Startpegel NaN ergibt volle Lautstaerke`() {
+        assertEquals(LautstaerkeAnstieg.VOLL, LautstaerkeAnstieg.pegel(Float.NaN, 30_000L, 0L), 0f)
+    }
+
+    @Test
+    fun `Startpegel ab voll ergibt volle Lautstaerke`() {
+        assertEquals(LautstaerkeAnstieg.VOLL, LautstaerkeAnstieg.pegel(1f, 30_000L, 0L), 0f)
+        assertEquals(LautstaerkeAnstieg.VOLL, LautstaerkeAnstieg.pegel(2f, 30_000L, 15_000L), 0f)
+    }
+
+    @Test
+    fun `negative vergangene Zeit ergibt den Startpegel, nicht weniger`() {
+        assertEquals(0.15f, LautstaerkeAnstieg.pegel(0.15f, 30_000L, -5_000L), genauigkeit)
+    }
+
+    // ---- Die Kurve selbst ------------------------------------------------------------------
+
+    @Test
+    fun `der Pegel steigt ueber die gesamte Dauer monoton`() {
+        var vorher = -1f
+        for (ms in 0L..30_000L step 200L) {
+            val jetzt = LautstaerkeAnstieg.pegel(0.10f, 30_000L, ms)
+            assertTrue("Pegel faellt bei $ms ms: $vorher -> $jetzt", jetzt >= vorher)
+            vorher = jetzt
+        }
+    }
+
+    @Test
+    fun `der Pegel bleibt immer zwischen Startpegel und voll`() {
+        for (ms in 0L..40_000L step 137L) {
+            val pegel = LautstaerkeAnstieg.pegel(0.10f, 30_000L, ms)
+            assertTrue("Pegel $pegel bei $ms ms unter dem Startwert", pegel >= 0.10f)
+            assertTrue("Pegel $pegel bei $ms ms ueber voll", pegel <= LautstaerkeAnstieg.VOLL)
+        }
+    }
+
+    @Test
+    fun `die Mitte liegt geometrisch, nicht arithmetisch`() {
+        // Bei geometrischer Interpolation von 0,01 auf 1,0 steht in der Mitte die Wurzel: 0,1.
+        // Arithmetisch waeren es 0,505 - der Unterschied IST die Eigenschaft, um die es geht:
+        // ein linear steigender Amplitudenwert klingt, als sei der Anstieg nach einem Viertel
+        // der Zeit schon vorbei. Faellt dieser Test, ist die Kurve auf linear zurueckgefallen.
+        assertEquals(0.1f, LautstaerkeAnstieg.pegel(0.01f, 20_000L, 10_000L), 0.001f)
+    }
+
+    // ---- Backstop --------------------------------------------------------------------------
+
+    @Test
+    fun `der Backstop liegt hinter dem letzten regulaeren Schritt`() {
+        val dauer = 30_000L
+        assertTrue(LautstaerkeAnstieg.backstopVerzoegerungMs(dauer) > dauer)
+    }
+}

--- a/app/src/test/java/com/github/f1rlefanz/cf_alarmfortimeoffice/backup/ConfigBackupTypeAndRangeTest.kt
+++ b/app/src/test/java/com/github/f1rlefanz/cf_alarmfortimeoffice/backup/ConfigBackupTypeAndRangeTest.kt
@@ -74,4 +74,33 @@ class ConfigBackupTypeAndRangeTest {
         assertNotNull(ConfigBackupUseCase.typeMismatch(prefs, "dnd_oncall_shifts", "string"))
         assertNull(ConfigBackupUseCase.typeMismatch(prefs, "dnd_oncall_shifts", "stringSet"))
     }
+
+    /**
+     * Die Bereichspruefung des Weckton-Anstiegs.
+     *
+     * WARUM DIESE BEIDEN SCHLUESSEL: Sie bestimmen, wie leise und wie lange der Wecker anlaeuft.
+     * Eine Datei mit `3600` Sekunden oder `1` Prozent ergibt einen Wecker, den man nicht hoert -
+     * und beides sind fuer sich genommen voellig gueltige Zahlen, die keine Typpruefung und kein
+     * `?:`-Default abfaengt. Der Lesepfad klemmt sie zwar zusaetzlich, aber nur hier erfaehrt der
+     * Nutzer nach einem Import ueberhaupt davon.
+     */
+    @Test
+    fun `unplausible Anstiegswerte werden abgelehnt`() {
+        assertNotNull(ConfigBackupFilter.rangeRejection("weckton_anstieg_sekunden", 3600))
+        assertNotNull(ConfigBackupFilter.rangeRejection("weckton_anstieg_sekunden", 0))
+        assertNotNull(ConfigBackupFilter.rangeRejection("weckton_anstieg_start_prozent", 0))
+        assertNotNull(ConfigBackupFilter.rangeRejection("weckton_anstieg_start_prozent", 101))
+    }
+
+    @Test
+    fun `plausible Anstiegswerte kommen durch`() {
+        assertNull(ConfigBackupFilter.rangeRejection("weckton_anstieg_sekunden", 30))
+        assertNull(ConfigBackupFilter.rangeRejection("weckton_anstieg_start_prozent", 15))
+        // Beide Raender sind gueltig: 5 s ist der kuerzeste sinnvolle Anlauf, 100 % heisst
+        // "kein Anstieg" - wirkungslos, aber harmlos.
+        assertNull(ConfigBackupFilter.rangeRejection("weckton_anstieg_sekunden", 5))
+        assertNull(ConfigBackupFilter.rangeRejection("weckton_anstieg_sekunden", 120))
+        assertNull(ConfigBackupFilter.rangeRejection("weckton_anstieg_start_prozent", 1))
+        assertNull(ConfigBackupFilter.rangeRejection("weckton_anstieg_start_prozent", 100))
+    }
 }

--- a/app/src/test/java/com/github/f1rlefanz/cf_alarmfortimeoffice/backup/Pruefrunde6BackupSchluesselInventurTest.kt
+++ b/app/src/test/java/com/github/f1rlefanz/cf_alarmfortimeoffice/backup/Pruefrunde6BackupSchluesselInventurTest.kt
@@ -33,7 +33,8 @@ class Pruefrunde6BackupSchluesselInventurTest {
 
     /**
      * Alle heute bewusst EXPORTIERBAREN Schluessel: die vom Nutzer eingestellten Groessen
-     * (Dimmer-Regeln, Nacht-Standard, DND-Politik, Hue-Zeitplan, Schlummer-Dauer, Hinweistexte).
+     * (Dimmer-Regeln, Nacht-Standard, DND-Politik, Hue-Zeitplan, Schlummer-Dauer, Weckton-Anstieg,
+     * Hinweistexte).
      */
     private val bewusstExportierbar = setOf(
         "bridge_id",
@@ -70,7 +71,10 @@ class Pruefrunde6BackupSchluesselInventurTest {
         "dnd_shift_excluded_shifts",
         "hue_schedule_rules",
         "shift_change_notification_enabled",
-        "snooze_minutes"
+        "snooze_minutes",
+        "weckton_anstieg_aktiv",
+        "weckton_anstieg_sekunden",
+        "weckton_anstieg_start_prozent"
     )
 
     @Test

--- a/app/src/test/java/com/github/f1rlefanz/cf_alarmfortimeoffice/viewmodel/AlarmViewModelSkipRestoreTest.kt
+++ b/app/src/test/java/com/github/f1rlefanz/cf_alarmfortimeoffice/viewmodel/AlarmViewModelSkipRestoreTest.kt
@@ -1,6 +1,7 @@
 package com.github.f1rlefanz.cf_alarmfortimeoffice.viewmodel
 
 import com.github.f1rlefanz.cf_alarmfortimeoffice.alarm.AlarmPrefs
+import com.github.f1rlefanz.cf_alarmfortimeoffice.alarm.WecktonAnstieg
 import com.github.f1rlefanz.cf_alarmfortimeoffice.error.ErrorHandler
 import com.github.f1rlefanz.cf_alarmfortimeoffice.masterpause.MasterPausePrefs
 import com.github.f1rlefanz.cf_alarmfortimeoffice.model.AlarmInfo
@@ -95,6 +96,10 @@ class AlarmViewModelSkipRestoreTest {
         }
         val alarmPrefs = mock<AlarmPrefs>()
         whenever(alarmPrefs.snoozeMinutes).thenReturn(flowOf(9))
+        // Pflicht, nicht Kosmetik: AlarmViewModel liest diesen Flow im
+        // Property-Initializer. Ohne Stub liefert der Mock null und das Konstruieren
+        // scheitert mit einer NPE - noch vor dem ersten Testschritt.
+        whenever(alarmPrefs.wecktonAnstieg).thenReturn(flowOf(WecktonAnstieg.AUS))
         val masterPausePrefs = mock<MasterPausePrefs>()
         masterPausePrefs.stub {
             on { pausedNow() } doReturn masterPaused

--- a/app/src/test/java/com/github/f1rlefanz/cf_alarmfortimeoffice/viewmodel/Pruefrunde6SkipManualAlarmTest.kt
+++ b/app/src/test/java/com/github/f1rlefanz/cf_alarmfortimeoffice/viewmodel/Pruefrunde6SkipManualAlarmTest.kt
@@ -1,6 +1,7 @@
 package com.github.f1rlefanz.cf_alarmfortimeoffice.viewmodel
 
 import com.github.f1rlefanz.cf_alarmfortimeoffice.alarm.AlarmPrefs
+import com.github.f1rlefanz.cf_alarmfortimeoffice.alarm.WecktonAnstieg
 import com.github.f1rlefanz.cf_alarmfortimeoffice.error.ErrorHandler
 import com.github.f1rlefanz.cf_alarmfortimeoffice.masterpause.MasterPausePrefs
 import com.github.f1rlefanz.cf_alarmfortimeoffice.model.AlarmInfo
@@ -149,6 +150,10 @@ class Pruefrunde6SkipManualAlarmTest {
         }
         val alarmPrefs = mock<AlarmPrefs>()
         whenever(alarmPrefs.snoozeMinutes).thenReturn(flowOf(9))
+        // Pflicht, nicht Kosmetik: AlarmViewModel liest diesen Flow im
+        // Property-Initializer. Ohne Stub liefert der Mock null und das Konstruieren
+        // scheitert mit einer NPE - noch vor dem ersten Testschritt.
+        whenever(alarmPrefs.wecktonAnstieg).thenReturn(flowOf(WecktonAnstieg.AUS))
         val masterPausePrefs = mock<MasterPausePrefs>()
         masterPausePrefs.stub {
             on { pausedNow() } doReturn false

--- a/app/src/test/java/com/github/f1rlefanz/cf_alarmfortimeoffice/viewmodel/Pruefrunde7SkipAnzeigeTest.kt
+++ b/app/src/test/java/com/github/f1rlefanz/cf_alarmfortimeoffice/viewmodel/Pruefrunde7SkipAnzeigeTest.kt
@@ -1,6 +1,7 @@
 package com.github.f1rlefanz.cf_alarmfortimeoffice.viewmodel
 
 import com.github.f1rlefanz.cf_alarmfortimeoffice.alarm.AlarmPrefs
+import com.github.f1rlefanz.cf_alarmfortimeoffice.alarm.WecktonAnstieg
 import com.github.f1rlefanz.cf_alarmfortimeoffice.error.ErrorHandler
 import com.github.f1rlefanz.cf_alarmfortimeoffice.masterpause.MasterPausePrefs
 import com.github.f1rlefanz.cf_alarmfortimeoffice.model.AlarmInfo
@@ -98,6 +99,10 @@ class Pruefrunde7SkipAnzeigeTest {
         }
         val alarmPrefs = mock<AlarmPrefs>()
         whenever(alarmPrefs.snoozeMinutes).thenReturn(flowOf(9))
+        // Pflicht, nicht Kosmetik: AlarmViewModel liest diesen Flow im
+        // Property-Initializer. Ohne Stub liefert der Mock null und das Konstruieren
+        // scheitert mit einer NPE - noch vor dem ersten Testschritt.
+        whenever(alarmPrefs.wecktonAnstieg).thenReturn(flowOf(WecktonAnstieg.AUS))
         val masterPausePrefs = mock<MasterPausePrefs>()
         masterPausePrefs.stub { on { pausedNow() } doReturn false }
 

--- a/app/src/test/java/com/github/f1rlefanz/cf_alarmfortimeoffice/viewmodel/Pruefrunde7SkipRuecknahmeAbbruchTest.kt
+++ b/app/src/test/java/com/github/f1rlefanz/cf_alarmfortimeoffice/viewmodel/Pruefrunde7SkipRuecknahmeAbbruchTest.kt
@@ -2,6 +2,7 @@ package com.github.f1rlefanz.cf_alarmfortimeoffice.viewmodel
 
 import androidx.lifecycle.viewModelScope
 import com.github.f1rlefanz.cf_alarmfortimeoffice.alarm.AlarmPrefs
+import com.github.f1rlefanz.cf_alarmfortimeoffice.alarm.WecktonAnstieg
 import com.github.f1rlefanz.cf_alarmfortimeoffice.error.ErrorHandler
 import com.github.f1rlefanz.cf_alarmfortimeoffice.masterpause.MasterPausePrefs
 import com.github.f1rlefanz.cf_alarmfortimeoffice.model.AlarmInfo
@@ -135,6 +136,10 @@ class Pruefrunde7SkipRuecknahmeAbbruchTest {
         }
         val alarmPrefs = mock<AlarmPrefs>()
         whenever(alarmPrefs.snoozeMinutes).thenReturn(flowOf(9))
+        // Pflicht, nicht Kosmetik: AlarmViewModel liest diesen Flow im
+        // Property-Initializer. Ohne Stub liefert der Mock null und das Konstruieren
+        // scheitert mit einer NPE - noch vor dem ersten Testschritt.
+        whenever(alarmPrefs.wecktonAnstieg).thenReturn(flowOf(WecktonAnstieg.AUS))
         val masterPausePrefs = mock<MasterPausePrefs>()
         masterPausePrefs.stub { on { pausedNow() } doReturn false }
 

--- a/app/src/test/java/com/github/f1rlefanz/cf_alarmfortimeoffice/viewmodel/Pruefrunde7SkipWiedereintrittTest.kt
+++ b/app/src/test/java/com/github/f1rlefanz/cf_alarmfortimeoffice/viewmodel/Pruefrunde7SkipWiedereintrittTest.kt
@@ -1,6 +1,7 @@
 package com.github.f1rlefanz.cf_alarmfortimeoffice.viewmodel
 
 import com.github.f1rlefanz.cf_alarmfortimeoffice.alarm.AlarmPrefs
+import com.github.f1rlefanz.cf_alarmfortimeoffice.alarm.WecktonAnstieg
 import com.github.f1rlefanz.cf_alarmfortimeoffice.error.ErrorHandler
 import com.github.f1rlefanz.cf_alarmfortimeoffice.masterpause.MasterPausePrefs
 import com.github.f1rlefanz.cf_alarmfortimeoffice.model.AlarmInfo
@@ -91,6 +92,10 @@ class Pruefrunde7SkipWiedereintrittTest {
         }
         val alarmPrefs = mock<AlarmPrefs>()
         whenever(alarmPrefs.snoozeMinutes).thenReturn(flowOf(9))
+        // Pflicht, nicht Kosmetik: AlarmViewModel liest diesen Flow im
+        // Property-Initializer. Ohne Stub liefert der Mock null und das Konstruieren
+        // scheitert mit einer NPE - noch vor dem ersten Testschritt.
+        whenever(alarmPrefs.wecktonAnstieg).thenReturn(flowOf(WecktonAnstieg.AUS))
         val masterPausePrefs = mock<MasterPausePrefs>()
         masterPausePrefs.stub { on { pausedNow() } doReturn false }
 

--- a/app/src/test/java/com/github/f1rlefanz/cf_alarmfortimeoffice/viewmodel/Pruefrunde8ManuellerWeckerTest.kt
+++ b/app/src/test/java/com/github/f1rlefanz/cf_alarmfortimeoffice/viewmodel/Pruefrunde8ManuellerWeckerTest.kt
@@ -4,6 +4,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.mutablePreferencesOf
 import com.github.f1rlefanz.cf_alarmfortimeoffice.alarm.AlarmPrefs
+import com.github.f1rlefanz.cf_alarmfortimeoffice.alarm.WecktonAnstieg
 import com.github.f1rlefanz.cf_alarmfortimeoffice.alarm.DirectBootAlarmStore
 import com.github.f1rlefanz.cf_alarmfortimeoffice.error.ErrorHandler
 import com.github.f1rlefanz.cf_alarmfortimeoffice.masterpause.MasterPausePrefs
@@ -145,6 +146,10 @@ class Pruefrunde8ManuellerWeckerTest {
 
         val alarmPrefs = mock<AlarmPrefs>()
         whenever(alarmPrefs.snoozeMinutes).thenReturn(flowOf(9))
+        // Pflicht, nicht Kosmetik: AlarmViewModel liest diesen Flow im
+        // Property-Initializer. Ohne Stub liefert der Mock null und das Konstruieren
+        // scheitert mit einer NPE - noch vor dem ersten Testschritt.
+        whenever(alarmPrefs.wecktonAnstieg).thenReturn(flowOf(WecktonAnstieg.AUS))
         val masterPausePrefs = mock<MasterPausePrefs>()
         masterPausePrefs.stub { on { pausedNow() } doReturn false }
 

--- a/app/src/test/java/com/github/f1rlefanz/cf_alarmfortimeoffice/viewmodel/Pruefrunde8StilleSchichtAnzeigeTest.kt
+++ b/app/src/test/java/com/github/f1rlefanz/cf_alarmfortimeoffice/viewmodel/Pruefrunde8StilleSchichtAnzeigeTest.kt
@@ -1,6 +1,7 @@
 package com.github.f1rlefanz.cf_alarmfortimeoffice.viewmodel
 
 import com.github.f1rlefanz.cf_alarmfortimeoffice.alarm.AlarmPrefs
+import com.github.f1rlefanz.cf_alarmfortimeoffice.alarm.WecktonAnstieg
 import com.github.f1rlefanz.cf_alarmfortimeoffice.error.ErrorHandler
 import com.github.f1rlefanz.cf_alarmfortimeoffice.masterpause.MasterPausePrefs
 import com.github.f1rlefanz.cf_alarmfortimeoffice.model.AlarmInfo
@@ -95,6 +96,10 @@ class Pruefrunde8StilleSchichtAnzeigeTest {
         }
         val alarmPrefs = mock<AlarmPrefs>()
         whenever(alarmPrefs.snoozeMinutes).thenReturn(flowOf(9))
+        // Pflicht, nicht Kosmetik: AlarmViewModel liest diesen Flow im
+        // Property-Initializer. Ohne Stub liefert der Mock null und das Konstruieren
+        // scheitert mit einer NPE - noch vor dem ersten Testschritt.
+        whenever(alarmPrefs.wecktonAnstieg).thenReturn(flowOf(WecktonAnstieg.AUS))
         val masterPausePrefs = mock<MasterPausePrefs>()
         masterPausePrefs.stub { on { pausedNow() } doReturn false }
 


### PR DESCRIPTION
## Worum es geht

Android liefert Weckton und Lautstärke; das Einzige, was dort fehlt, ist ein sanfter Anstieg. Genau der kommt hinzu — und sonst nichts: **keine App-eigene Ton- oder Lautstärkeauswahl daneben**, die wäre eine zweite Wahrheit und eine Stelle, an der die App leiser sein kann, als der Nutzer glaubt.

Einstellbar im Wecker-Tab, unter der Schlummer-Dauer: Schalter, Anlaufzeit (10–120 s) und Startlautstärke (5–60 %). **Ab Werk AUS** — eine stille Umstellung auf „startet leise" wäre eine Änderung am Weckverhalten, die niemand bestellt hat und die man erst bemerkt, wenn man verschlafen hat.

## Wie es gebaut ist

Der Anstieg skaliert ausschließlich den eigenen `MediaPlayer` per `setVolume()`. `AudioManager.setStreamVolume(STREAM_ALARM, …)` ist bewusst **nicht** benutzt: stirbt der Prozess mitten im Anstieg — nachts, ohne Zeugen —, bliebe die Alarm-Lautstärke des Geräts dauerhaft auf dem Anfangswert stehen, und das nächste Wecken wäre leise, ohne dass irgendetwas darauf hinweist.

Weil das die einzige Stelle der App ist, an der der Wecker absichtlich leise anfängt, drei Sicherungen:

1. **Backstop** — ein zweiter, von der Schrittkette unabhängiger `postDelayed` stellt am Ende bedingungslos auf volle Lautstärke. Reißt die Kette ab, wäre der Wecker sonst auf dem Anfangspegel eingefroren.
2. **Generationsschutz** — jeder Callback prüft `playerGeneration`, damit ein Anstieg des vorigen Players den neuen nicht leiser dreht (stop → snooze → start).
3. **Eigener Handler** — nicht der `vorweckHandler`: beide räumen mit `removeCallbacksAndMessages(null)` auf, und der ausstehende Vordergrund-Start darf dabei nicht mitgelöscht werden.

Die Kurve ist geometrisch (linear in dB), nicht linear: `setVolume()` nimmt eine Amplitude, das Ohr hört logarithmisch.

**Jede Unklarheit degradiert auf volle Lautstärke**, nie auf einen leisen Wecker — unlesbarer DataStore, fehlende Intent-Extras, unbrauchbare Eingaben. Direct Boot fällt darunter: der Receiver liest den CE-Storage dort nicht, der Anstieg entfällt also.

Werte gehen denselben Weg wie die Schlummer-Dauer: `AlarmPrefs` → einmal pro Feuern im `AlarmReceiver` gelesen → Intent-Extra. Der Weckpfad im Dienst bekommt keinen DataStore-Read.

## Was noch dazugehört

- 13 Tests auf den reinen Rechenkern (`LautstaerkeAnstieg`): beide Kurvenenden, Monotonie, und dass jede unklare Eingabe laut wird.
- Import und Android-Backup: beide neuen Zahlen sind bereichsgeprüft — sonst schleust eine Datei einen Wecker ein, den man nicht hört.
- Die Zusicherungen stehen im Skill `cfalarm-wecker-und-boot`.
- Aufgeräumt: die drei gleichartigen Auswahlzeilen im Wecker-Tab teilen sich jetzt eine Bauart (`AuswahlRow`) statt dreimal derselben Barrierefreiheits-Falle.
- Sieben ViewModel-Tests mussten nachgezogen werden: `AlarmViewModel` liest den neuen Flow im Property-Initializer, ein ungestubbter Mock liefert dort `null`.

## Offen — bitte mitlesen

- **Der Code ist nie übersetzt worden.** Der Container konnte nicht bauen (`api.foojay.io` und `dl.google.com` sind per Netzwerkrichtlinie gesperrt, beides geprüft — auch der Spiegel `maven.google.com` leitet auf den gesperrten Host um). **Dieser CI-Lauf ist die erste echte Prüfung.**
- **Die Vibration ist nicht Teil des Anstiegs** — sie startet weiterhin sofort in voller Stärke. Das untergräbt das „sanft" auf einem vibrierenden Gerät spürbar; es zu ändern hieße aber, die Weckwirkung selbst zu ändern. Bewusst offen gelassen.
- **Versionsbump und Changelog fehlen absichtlich.** Ein Bump auf `main` liefert in den internen Play-Track aus — das ist eine Veröffentlichungsentscheidung und gehört dir, nicht diesem PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144s3kitJG8SNWwEJXjU4pE

---
_Generated by [Claude Code](https://claude.ai/code/session_0144s3kitJG8SNWwEJXjU4pE)_